### PR TITLE
Update idose.js to allow decimal input.

### DIFF
--- a/src/commands/global/bug.js
+++ b/src/commands/global/bug.js
@@ -7,7 +7,11 @@ const template = require('../../utils/embed-template');
 
 const PREFIX = path.parse(__filename).name;
 
-const channelDevId = process.env.channel_development;
+const {
+  ownerId,
+  role_developer: roleDeveloperId,
+  channel_development: channelDevId,
+} = process.env;
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -22,13 +26,17 @@ module.exports = {
     const bugReport = interaction.options.getString('bug_report') || parameters;
     logger.debug(`[${PREFIX}] bugReport:`, bugReport);
 
-    const botOwner = interaction.client.users.cache.get(process.env.ownerId);
+    const botOwner = interaction.client.users.cache.get(ownerId);
+    const botOwnerEmbed = template.embedTemplate()
+      .setColor('RANDOM')
+      .setDescription(`Hey ${botOwner.toString()},\n${username}${guildMessage} reports:\n${bugReport}`);
+    botOwner.send({ embeds: [botOwnerEmbed] });
 
-    logger.debug(`[${PREFIX}] channel_dev_id:`, channelDevId);
+    const developerRole = interaction.guild.roles.cache.find(role => role.id === roleDeveloperId);
     const devChan = interaction.client.channels.cache.get(channelDevId);
     const devEmbed = template.embedTemplate()
       .setColor('RANDOM')
-      .setDescription(`Hey ${botOwner.toString()},\n${username}${guildMessage} reports:\n${bugReport}`);
+      .setDescription(`Hey ${developerRole.toString()}s, a user submitted a bug report:\n${bugReport}`);
     devChan.send({ embeds: [devEmbed] });
 
     const embed = template.embedTemplate()

--- a/src/commands/global/dose.js
+++ b/src/commands/global/dose.js
@@ -11,7 +11,7 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('dose')
     .setDescription('Log your dosages (offline, only you can see this)!')
-    .addIntegerOption(option => option.setName('volume')
+    .addNumberOption(option => option.setName('volume')
       .setDescription('How much?')
       .setRequired(true))
     .addStringOption(option => option.setName('units')
@@ -36,7 +36,7 @@ module.exports = {
 
   async execute(interaction, parameters) {
     const substance = interaction.options.getString('substance') || parameters.at(0);
-    const volume = interaction.options.getInteger('volume') || parameters.at(1);
+    const volume = interaction.options.getNumber('volume') || parameters.at(1);
     const units = interaction.options.getString('units') || parameters.at(2);
 
     const date = new Date();

--- a/src/commands/guild/idose.js
+++ b/src/commands/guild/idose.js
@@ -99,14 +99,14 @@ module.exports = {
     .addSubcommand(subcommand => subcommand
       .setName('set')
       .setDescription('Record when you dosed something')
-      .addIntegerOption(option => option.setName('volume')
+      .addNumberOption(option => option.setName('volume')
         .setDescription('How much?')
         .setRequired(true))
       .addStringOption(option => option.setName('units')
         .setDescription('What units?')
         .setRequired(true)
         .addChoice('mg (milligrams)', 'mg (milligrams)')
-        .addChoice('ml (milliliters)', 'ml (milliliters)')
+        .addChoice('mL (milliliters)', 'mL (milliliters)')
         .addChoice('µg (micrograms)', 'µg (micrograms)')
         .addChoice('g (grams)', 'g (grams)')
         .addChoice('oz (ounces)', 'oz (ounces)')
@@ -222,7 +222,7 @@ module.exports = {
     if (command === 'set') {
       // logger.debug(`[${PREFIX}] Command: ${command}`);
       const substance = interaction.options.getString('substance') || parameters.at(1);
-      const volume = interaction.options.getInteger('volume') || parameters.at(2);
+      const volume = interaction.options.getNumber('volume') || parameters.at(2);
       const units = interaction.options.getString('units') || parameters.at(3);
       let offset = '';
       // logger.debug(`[${PREFIX}] option: ${interaction.options.getString('offset')}`);


### PR DESCRIPTION
In response to the following...

> **`TRIPBOT USER` reports:** cannot report decimal ml doses, like when I dose 1.5 ml of gbl it tells me to input a valid integer but rounding to the nearest ml is a huge difference in dosing

This should work just fine as Firebase does not distinguish between integers and decimals.

![CleanShot 2022-05-14 at 06 18 32@2x](https://user-images.githubusercontent.com/612499/168421742-668be19b-3104-4d0a-8d3e-687f5575bfb2.png)
