### PR TITLE
Hotfix for /profile

### DIFF
--- a/src/discord/commands/guild/profile.js
+++ b/src/discord/commands/guild/profile.js
@@ -97,7 +97,7 @@ module.exports = {
 
     const targetEmbed = template.embedTemplate()
       .setColor('BLUE')
-      .setDescription(`${targetData.accountName}'s profile!`)
+      .setDescription(`${target.username}'s profile!`)
       .addFields(
         { name: 'Username', value: targetUsername, inline: true },
         { name: 'Nickname', value: `${target.nickname ? target.nickname : 'No nickname'}`, inline: true },


### PR DESCRIPTION
I made it use the discord username as embed title instead of some 'accountName' from firebase, because it is undefined.