### PR TITLE
Fixed negative numbers in /birthday set

### DIFF
--- a/src/discord/commands/guild/d.birthday.ts
+++ b/src/discord/commands/guild/d.birthday.ts
@@ -60,8 +60,8 @@ async function birthdaySet(
     return;
   }
 
-  if (!day) {
-    await interaction.editReply({ content: 'You need to specify a day!' });
+  if (day === null || (day !== null && day < 1)) {
+    await interaction.editReply({ content: 'You need to specify a valid day!' });
     return;
   }
 

--- a/src/discord/commands/guild/d.birthday.ts
+++ b/src/discord/commands/guild/d.birthday.ts
@@ -60,7 +60,7 @@ async function birthdaySet(
     return;
   }
 
-  if (day === null || (day !== null && day < 1)) {
+  if (!day || day < 1) {
     await interaction.editReply({ content: 'You need to specify a valid day!' });
     return;
   }


### PR DESCRIPTION
The day of birth could be a negative number and result in an error. 

The new version of the conditional checks that the day is not null/undefined and that the day is not less than 1.

This is a fix for issue #796.