### PR TITLE
Added char limit to talk-to-mods feedback popup & warn user of limit

### DIFF
--- a/src/discord/utils/techHelp.ts
+++ b/src/discord/utils/techHelp.ts
@@ -73,11 +73,13 @@ export async function techHelpClick(interaction:ButtonInteraction) {
     .setCustomId(`techHelpSubmit~${interaction.id}`)
     .setTitle(`${interaction.guild.name} Feedback`)
     .addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(new TextInputBuilder()
-      .setLabel('What is your issue? Be super detailed! (2000 character limit)')
+      .setLabel('What is your issue? Be super detailed!')
       .setStyle(TextInputStyle.Paragraph)
       .setPlaceholder(placeholder)
       .setCustomId(`${issueType}IssueInput`)
-      .setRequired(true))));
+      .setRequired(true)
+      .setMinLength(10)
+      .setMaxLength(2000))));
 
   const filter = (i:ModalSubmitInteraction) => i.customId.includes('techHelpSubmit');
   interaction.awaitModalSubmit({ filter, time: 0 })
@@ -93,14 +95,6 @@ export async function techHelpClick(interaction:ButtonInteraction) {
       // Get whatever they sent in the modal
       const modalInput = i.fields.getTextInputValue(`${issueType}IssueInput`);
       // log.debug(F, `modalInput: ${modalInput}!`);
-
-      if (modalInput.length > 2000) {
-        await interaction.reply({
-          content: 'Your feedback must be 2000 characters or less!',
-          ephemeral: true,
-        });
-        return;
-      }
 
       // // Get the actor
       const actor = i.user;

--- a/src/discord/utils/techHelp.ts
+++ b/src/discord/utils/techHelp.ts
@@ -93,12 +93,12 @@ export async function techHelpClick(interaction:ButtonInteraction) {
       // Get whatever they sent in the modal
       const modalInput = i.fields.getTextInputValue(`${issueType}IssueInput`);
       // log.debug(F, `modalInput: ${modalInput}!`);
-      
+
       if (modalInput.length > 2000) {
         await interaction.reply({
           content: 'Your feedback must be 2000 characters or less!',
           ephemeral: true,
-        })
+        });
         return;
       }
 

--- a/src/discord/utils/techHelp.ts
+++ b/src/discord/utils/techHelp.ts
@@ -73,7 +73,7 @@ export async function techHelpClick(interaction:ButtonInteraction) {
     .setCustomId(`techHelpSubmit~${interaction.id}`)
     .setTitle(`${interaction.guild.name} Feedback`)
     .addComponents(new ActionRowBuilder<TextInputBuilder>().addComponents(new TextInputBuilder()
-      .setLabel('What is your issue? Be super detailed!')
+      .setLabel('What is your issue? Be super detailed! (2000 character limit)')
       .setStyle(TextInputStyle.Paragraph)
       .setPlaceholder(placeholder)
       .setCustomId(`${issueType}IssueInput`)
@@ -93,6 +93,14 @@ export async function techHelpClick(interaction:ButtonInteraction) {
       // Get whatever they sent in the modal
       const modalInput = i.fields.getTextInputValue(`${issueType}IssueInput`);
       // log.debug(F, `modalInput: ${modalInput}!`);
+      
+      if (modalInput.length > 2000) {
+        await interaction.reply({
+          content: 'Your feedback must be 2000 characters or less!',
+          ephemeral: true,
+        })
+        return;
+      }
 
       // // Get the actor
       const actor = i.user;


### PR DESCRIPTION
**I can't test this currently** but this should fix it. Note the interaction is replied to with .reply() instead of .editReply() as I'm not sure what reply there would be to edit here. If that is the wrong way to do it, let me know and I'll fix it.

Speaking of which I see other interactions in this function that use .editReply() directly above my edit. Do those work properly?

Lastly, it would be nice to verify that this looks fine on the UI in both mobile and desktop, "What is your issue? Be super detailed! (2000 character limit)". I like how short it was before but wasn't sure how else to notify them, and this looked better to me than editing the placeholder below it. It would be frustrating for a user if someone wrote 3000 characters of feedback, didn't copy it, then the request failed and they lost their 3000 chars of feedback, hence the warning.

This should fix issue #659.