### PR TITLE
Fix ~tripsit so that it only works in Tripsitting channels.

### DIFF
--- a/src/discord/utils/messageCommand.ts
+++ b/src/discord/utils/messageCommand.ts
@@ -5,6 +5,7 @@ import {
   Role,
   PermissionResolvable,
   EmbedBuilder,
+  TextChannel,
 } from 'discord.js';
 import { stripIndents } from 'common-tags';
 import { sleep } from '../commands/guild/d.bottest';
@@ -18,6 +19,14 @@ const F = f(__filename); // eslint-disable-line
 const helpCounter = new Map<string, number>();
 
 export default messageCommand;
+
+const tripsitChannels = [
+  env.CHANNEL_TRIPSIT,
+  env.CHANNEL_OPENTRIPSIT1,
+  env.CHANNEL_OPENTRIPSIT2,
+  env.CHANNEL_WEBTRIPSIT1,
+  env.CHANNEL_WEBTRIPSIT2,
+];
 
 const sadStuff = [
   'sadface',
@@ -160,6 +169,15 @@ export async function messageCommand(message: Message): Promise<void> {
     const command = message.content.split(' ')[0].slice(1);
     // log.debug(F, `command: ${command}`);
     if (command === 'tripsit') {
+      // If not in a tripsit channel and not in a specific users custom tripsit channel, tell them where to go and return.
+      if (!tripsitChannels.includes(message.channel.id) && !(message.channel as TextChannel).name.endsWith(`${message.author.displayName}'s channel!`)) {
+        const channelTripsit = await message.guild.channels.fetch(env.CHANNEL_TRIPSIT) as TextChannel;
+        const channelOpenTripsit1 = await message.guild.channels.fetch(env.CHANNEL_OPENTRIPSIT1) as TextChannel;
+        await message.channel.send(
+          stripIndents`Hey ${displayName}, this command is reserved for the tripsitting channels. Head on over to ${channelTripsit} or ${channelOpenTripsit1} and try again if you need help! <3`,
+        );
+        return;
+      }
       const now = Date.now().valueOf();
       if (helpCounter.has(message.author.id)) {
         const lastTime = helpCounter.get(message.author.id);


### PR DESCRIPTION
This change should make ~tripsit only work in tripsitting channels, including custom private ones after pressing the "I need help" button in # tripsit. Tested except for custom private channels as I can't get that to work on my end yet. I am quite confident that should work though.

With that in mind, the private tripsit rooms need a quick test.

This is a fix for issue #775 