### PR TITLE
Prevent back-to-back combo breaking in the counting game

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "db:validateSchema": "docker exec -it tripbot npx prisma validate",
     "db:generateClient": "npx prisma generate && docker exec -it tripbot npx prisma generate",
     "db:pushDev": "docker exec -it tripbot npx prisma db push && npm run tripbot:db:generate",
-    "db:migrateDev": "docker exec -it tripbot npx prisma migrate dev -n welcome_fix",
+    "db:migrateDev": "docker exec -it tripbot npx prisma migrate dev -n counting_breaks",
     "db:seed": "docker exec -it tripbot npx prisma db seed",
     "## PGADMIN ##": "",
     "pgadmin": "docker compose --project-name tripbot up -d --force-recreate --build tripbot_pgadmin",

--- a/src/discord/commands/guild/d.counting.ts
+++ b/src/discord/commands/guild/d.counting.ts
@@ -21,7 +21,9 @@ const F = f(__filename);
 
 interface ComboHistoryObj {
   user_id: string | null;
-  broken_timestamp: number;
+  game_id: string;
+  count: Number;
+  last_broken_at: number;
 }
 
 function calcTotalPot(
@@ -156,8 +158,6 @@ export async function countingSetup(
       last_number_broken_by: countingData?.last_number_broken_by ?? null,
       last_number_broken_date: countingData?.last_number_broken_date ?? null,
 
-      combo_breaking_history: countingData?.combo_breaking_history ?? JSON.stringify([]),
-
       record_number: countingData?.record_number ?? 0,
       record_number_message_id: countingData?.record_number_message_id ?? null,
       record_number_message_date: countingData?.record_number_message_date ?? null,
@@ -192,9 +192,6 @@ export async function countingSetup(
       last_number_broken_date: countingData?.last_number_broken_date
         ? countingData.last_number_broken_date
         : null,
-      combo_breaking_history: countingData?.combo_breaking_history
-        ? countingData.combo_breaking_history
-        : JSON.stringify([]),
     },
   });
 
@@ -282,6 +279,17 @@ export async function countMessage(message: Message): Promise<void> {
   if (!countingData) return; // If not a counting channel then ignore all messages
   log.debug(F, `countingData: ${JSON.stringify(countingData, null, 2)} `);
 
+  // Get recent combo breakers
+  const recentComboBreakers = await db.counting_breaks.findMany({
+    where: {
+      game_id: countingData.type,
+    },
+    orderBy: {
+      last_broken_at: 'desc'
+    },
+    take: 4,
+  });
+
   // Process the new message. If it's the next number after current_number, then update the DB
   // If it's not the next number, then still update the db with the user who broke the combo
 
@@ -316,10 +324,10 @@ export async function countMessage(message: Message): Promise<void> {
     { before: message.id },
   ) as Collection<string, Message<true>>;
   const lastMessage = channelMessages
-    .filter(m => m.author.id === message.author.id) // Messages sent by the user
-    .filter(m => !Number.isNaN(parseInt(m.cleanContent, 10))) // That are numbers
-    .filter(m => m.createdTimestamp > Date.now() - (1000 * 60 * 60)) // That are within one hour
-    .sort((a, b) => b.createdTimestamp - a.createdTimestamp) // Sorted by most recent
+    .filter((m: { author: { id: any; }; }) => m.author.id === message.author.id) // Messages sent by the user
+    .filter((m: { cleanContent: string; }) => !Number.isNaN(parseInt(m.cleanContent, 10))) // That are numbers
+    .filter((m: { createdTimestamp: number; }) => m.createdTimestamp > Date.now() - (1000 * 60 * 60)) // That are within one hour
+    .sort((a: { createdTimestamp: number; }, b: { createdTimestamp: number; }) => b.createdTimestamp - a.createdTimestamp) // Sorted by most recent
     .first(); // Get the first one
 
   if (lastMessage && countingData.type === 'TOKEN'
@@ -331,17 +339,18 @@ export async function countMessage(message: Message): Promise<void> {
   if (number !== countingData.current_number + 1) {
     await message.channel.messages.fetch(countingData.current_number_message_id);
 
-    const comboBreakingHistory: ComboHistoryObj[] = JSON.parse(countingData.combo_breaking_history as string || '[]');
+    //const comboBreakingHistory: ComboHistoryObj[] = countingData.combo_breaking_history;
 
-    if (comboBreakingHistory.length > 4) {
-      comboBreakingHistory.shift();
-    }
-
-    if (comboBreakingHistory.length > 0) {
+    // if (comboBreakingHistory.length > 4) {
+    //   comboBreakingHistory.shift();
+    // }
+    
+    if (recentComboBreakers) {
       // Check if the user has broken the combo recently, and if so, flag them and prevent the break.
+      // REMOVE THIS COMMENT AFTER READING - THIS SHOULD BE FINE.
       let userCanBreakCombo = true;
-      comboBreakingHistory.forEach(comboHistoryObj => {
-        if (message.author.id === comboHistoryObj.user_id) {
+      recentComboBreakers.forEach((comboBreak: { user_id: string; }) => {
+        if (message.author.id === comboBreak.user_id) {
           userCanBreakCombo = false;
         }
       });
@@ -399,18 +408,13 @@ export async function countMessage(message: Message): Promise<void> {
       return;
     }
 
-    comboBreakingHistory.push({
-      user_id: message.author.id,
-      broken_timestamp: Date.now(),
-    });
-
     countingData.last_number = countingData.current_number;
     countingData.last_number_message_id = countingData.current_number_message_id;
     countingData.last_number_message_date = countingData.current_number_message_date;
     countingData.last_number_message_author = countingData.current_number_message_author;
     countingData.last_number_broken_by = message.author.id;
     countingData.last_number_broken_date = new Date();
-    countingData.combo_breaking_history = JSON.stringify(comboBreakingHistory);
+    // countingData.combo_breaking_history = JSON.stringify(comboBreakingHistory);
 
     // If the number is not the next number in the sequence...
     let recordMessage = '';
@@ -492,6 +496,21 @@ export async function countMessage(message: Message): Promise<void> {
       create: countingData,
       update: countingData,
     });
+
+
+    // THIS IS WHERE I LEFT OFF. 
+
+    await db.counting_breaks.upsert({
+      where: {
+        game_id: countingData.type,
+      },
+      create: {
+        user_id: message.author.id,
+        game_id: countingData.type,
+        count: countingData.current_number,
+      },
+    });
+    
 
     // Send a message to the channel
     await message.channel.send({
@@ -587,7 +606,7 @@ export async function countMessage(message: Message): Promise<void> {
     // Look up the persona of every user in the currentData.current_stakeholders string
     // Give each of those personas a fraction of the pot: (totalPot / currentData.current_stakeholders.length)
     const stakeholderIds = countingData.current_stakeholders.split(',');
-    await Promise.all(stakeholderIds.map(async discordId => {
+    await Promise.all(stakeholderIds.map(async (discordId: any) => {
       // const userData = await getUser(message.author.id, null, null);
       const userData = await db.users.upsert({
         where: {
@@ -651,10 +670,10 @@ export const counting: SlashCommandBeta = {
   data: new SlashCommandBuilder()
     .setName('counting')
     .setDescription('All things with counting!')
-    .addSubcommand(subcommand => subcommand
+    .addSubcommand((subcommand: { setName: (arg0: string) => { (): any; new(): any; setDescription: { (arg0: string): { (): any; new(): any; addStringOption: { (arg0: (option: any) => any): any; new(): any; }; }; new(): any; }; }; }) => subcommand
       .setName('setup')
       .setDescription('Set up a Counting channel!')
-      .addStringOption(option => option
+      .addStringOption((option: { setDescription: (arg0: string) => { (): any; new(): any; setName: { (arg0: string): { (): any; new(): any; addChoices: { (arg0: { name: string; value: string; }, arg1: { name: string; value: string; }, arg2: { name: string; value: string; }): any; new(): any; }; }; new(): any; }; }; }) => option
         .setDescription('What kind of counting game?')
         .setName('type')
         .addChoices(
@@ -662,21 +681,21 @@ export const counting: SlashCommandBeta = {
           { name: 'Token', value: 'TOKEN' },
           { name: 'Normal', value: 'NORMAL' },
         )))
-    .addSubcommand(subcommand => subcommand
+    .addSubcommand((subcommand: { setName: (arg0: string) => { (): any; new(): any; setDescription: { (arg0: string): { (): any; new(): any; addBooleanOption: { (arg0: (option: any) => any): any; new(): any; }; }; new(): any; }; }; }) => subcommand
       .setName('scores')
       .setDescription('Get the scores for a Counting channel!')
-      .addBooleanOption(option => option.setName('ephemeral')
+      .addBooleanOption((option: { setName: (arg0: string) => { (): any; new(): any; setDescription: { (arg0: string): any; new(): any; }; }; }) => option.setName('ephemeral')
         .setDescription('Set to "True" to show the response only to you')))
-    .addSubcommand(subcommand => subcommand
+    .addSubcommand((subcommand: { setName: (arg0: string) => { (): any; new(): any; setDescription: { (arg0: string): { (): any; new(): any; addIntegerOption: { (arg0: (option: any) => any): { (): any; new(): any; addBooleanOption: { (arg0: (option: any) => any): { (): any; new(): any; addStringOption: { (arg0: (option: any) => any): any; new(): any; }; }; new(): any; }; }; new(): any; }; }; new(): any; }; }; }) => subcommand
       .setName('reset')
       .setDescription('Reset the counting channel!')
-      .addIntegerOption(option => option
+      .addIntegerOption((option: { setDescription: (arg0: string) => { (): any; new(): any; setName: { (arg0: string): any; new(): any; }; }; }) => option
         .setDescription('The number to set the channel to')
         .setName('number'))
-      .addBooleanOption(option => option
+      .addBooleanOption((option: { setName: (arg0: string) => { (): any; new(): any; setDescription: { (arg0: string): any; new(): any; }; }; }) => option
         .setName('purge')
         .setDescription('Set to "True" to start completely fresh'))
-      .addStringOption(option => option
+      .addStringOption((option: { setDescription: (arg0: string) => { (): any; new(): any; setName: { (arg0: string): { (): any; new(): any; addChoices: { (arg0: { name: string; value: string; }, arg1: { name: string; value: string; }, arg2: { name: string; value: string; }): any; new(): any; }; }; new(): any; }; }; }) => option
         .setDescription('What kind of counting game?')
         .setName('type')
         .addChoices(
@@ -684,7 +703,7 @@ export const counting: SlashCommandBeta = {
           { name: 'Token', value: 'TOKEN' },
           { name: 'Normal', value: 'NORMAL' },
         )))
-    .addSubcommand(subcommand => subcommand
+    .addSubcommand((subcommand: { setName: (arg0: string) => { (): any; new(): any; setDescription: { (arg0: string): any; new(): any; }; }; }) => subcommand
       .setName('end')
       .setDescription('End the counting game!')),
   async execute(interaction) {

--- a/src/discord/commands/guild/d.counting.ts
+++ b/src/discord/commands/guild/d.counting.ts
@@ -376,7 +376,7 @@ export async function countMessage(message: Message): Promise<void> {
     countingData.last_number_broken_date = new Date();
 
     if (message.author.id === countingData.last_number_broken_by) {
-      await message.channel.send('You cannot break a combo twice in a row!')
+      await message.channel.send('You cannot break a combo twice in a row!');
       return;
     }
 

--- a/src/discord/commands/guild/d.counting.ts
+++ b/src/discord/commands/guild/d.counting.ts
@@ -331,17 +331,14 @@ export async function countMessage(message: Message): Promise<void> {
   if (number !== countingData.current_number + 1) {
     await message.channel.messages.fetch(countingData.current_number_message_id);
 
-    // Check if the user has broken the combination recently, and if so, deny them.
     const comboBreakingHistory: ComboHistoryObj[] = JSON.parse(countingData.combo_breaking_history as string || '[]');
 
     if (comboBreakingHistory.length > 4) {
       comboBreakingHistory.shift();
     }
 
-    // If we have history of someone breaking the combo, do the checks.
     if (comboBreakingHistory.length > 0) {
-      // This filter checks if the combo hasn't been broken more than 4 times in 4 days by the user, if not, remove the user from the list so they can break it.
-      // Otherwise, if they have broken recently, flag it to prevent breaking it again.
+      // Check if the user has broken the combo recently, and if so, flag them and prevent the break.
       let userCanBreakCombo = true;
       comboBreakingHistory.forEach(comboHistoryObj => {
         if (message.author.id === comboHistoryObj.user_id) {

--- a/src/discord/commands/guild/d.counting.ts
+++ b/src/discord/commands/guild/d.counting.ts
@@ -375,6 +375,11 @@ export async function countMessage(message: Message): Promise<void> {
     countingData.last_number_broken_by = message.author.id;
     countingData.last_number_broken_date = new Date();
 
+    if (message.author.id === countingData.last_number_broken_by) {
+      await message.channel.send('You cannot break a combo twice in a row!')
+      return;
+    }
+
     // If the number is not the next number in the sequence...
     let recordMessage = '';
     // Check if a new record was set

--- a/src/discord/commands/guild/d.counting.ts
+++ b/src/discord/commands/guild/d.counting.ts
@@ -332,7 +332,7 @@ export async function countMessage(message: Message): Promise<void> {
     await message.channel.messages.fetch(countingData.current_number_message_id);
 
     // Check if the user has broken the combination recently, and if so, deny them.
-    let comboBreakingHistory: ComboHistoryObj[] = JSON.parse(countingData.combo_breaking_history as string || '[]');
+    const comboBreakingHistory: ComboHistoryObj[] = JSON.parse(countingData.combo_breaking_history as string || '[]');
 
     if (comboBreakingHistory.length > 4) {
       comboBreakingHistory.shift();
@@ -342,9 +342,9 @@ export async function countMessage(message: Message): Promise<void> {
     if (comboBreakingHistory.length > 0) {
       // This filter checks if the combo hasn't been broken more than 4 times in 4 days by the user, if not, remove the user from the list so they can break it.
       // Otherwise, if they have broken recently, flag it to prevent breaking it again.
-      var userCanBreakCombo = true;
-      comboBreakingHistory.forEach(function(comboHistoryObj) {
-        if(message.author.id === comboHistoryObj.user_id) {
+      let userCanBreakCombo = true;
+      comboBreakingHistory.forEach(comboHistoryObj => {
+        if (message.author.id === comboHistoryObj.user_id) {
           userCanBreakCombo = false;
         }
       });

--- a/src/discord/commands/guild/d.counting.ts
+++ b/src/discord/commands/guild/d.counting.ts
@@ -369,7 +369,7 @@ export async function countMessage(message: Message): Promise<void> {
       
       You may not know, but you're breaking the combo!
 
-      The current number is ${countingData.current_number}, if you want to join the game, type the next number in the series!
+      The current number is ${countingData.current_number}, if you want to join the game, type the next number in the series! 
       `;
       if (countingData.type === 'HARDCORE') {
         messageReply += 'If you break the combo again, you\'ll be timed out for 24 hours!';

--- a/src/prisma/tripbot/migrations/20240714130515_counting/migration.sql
+++ b/src/prisma/tripbot/migrations/20240714130515_counting/migration.sql
@@ -1,0 +1,19 @@
+-- CreateTable
+CREATE TABLE "counting_breaks" (
+    "id" UUID NOT NULL DEFAULT uuid_generate_v4(),
+    "user_id" TEXT NOT NULL,
+    "game_id" "counting_type" NOT NULL,
+    "count" INTEGER NOT NULL,
+    "last_broken_at" TIMESTAMPTZ(6) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "counting_breaks_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE UNIQUE INDEX "counting_userid_gameid_unique" ON "counting_breaks"("user_id", "game_id");
+
+-- AddForeignKey
+ALTER TABLE "counting_breaks" ADD CONSTRAINT "counting_userid_foreign" FOREIGN KEY ("user_id") REFERENCES "users"("discord_id") ON DELETE NO ACTION ON UPDATE NO ACTION;
+
+-- AddForeignKey
+ALTER TABLE "counting_breaks" ADD CONSTRAINT "counting_gameid_foreign" FOREIGN KEY ("id") REFERENCES "counting"("id") ON DELETE NO ACTION ON UPDATE NO ACTION;

--- a/src/prisma/tripbot/schema.prisma
+++ b/src/prisma/tripbot/schema.prisma
@@ -34,6 +34,7 @@ model counting {
   last_number_message_author    String?
   last_number_broken_by         String?
   last_number_broken_date       DateTime?      @db.Timestamptz(6)
+  combo_breaking_history        String?
   record_number                 Int            @default(0)
   record_number_message_id      String?
   record_number_message_date    DateTime?      @db.Timestamptz(6)

--- a/src/prisma/tripbot/schema.prisma
+++ b/src/prisma/tripbot/schema.prisma
@@ -34,7 +34,6 @@ model counting {
   last_number_message_author    String?
   last_number_broken_by         String?
   last_number_broken_date       DateTime?      @db.Timestamptz(6)
-  combo_breaking_history        String?
   record_number                 Int            @default(0)
   record_number_message_id      String?
   record_number_message_date    DateTime?      @db.Timestamptz(6)
@@ -44,6 +43,18 @@ model counting {
   discord_guilds                discord_guilds @relation(fields: [guild_id], references: [id], onDelete: NoAction, onUpdate: NoAction, map: "counting_guildid_foreign")
 
   @@unique([guild_id, channel_id], map: "counting_guildid_channelid_unique")
+}
+
+model counting_breaks {
+  id                String @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
+  user_id           String
+  game_id           counting_type
+  count             Int
+  last_broken_at    DateTime @default(now()) @db.Timestamptz(6)
+
+  user users @relation(fields: [user_id], references: [discord_id], onDelete: NoAction, onUpdate: NoAction, map: "counting_userid_foreign")
+
+  @@unique([user_id, game_id], map: "counting_userid_gameid_unique")
 }
 
 model drugs {
@@ -175,6 +186,7 @@ model users {
   wordle_scores                                             wordle_scores[]
   connections_scores                                        connections_scores[]
   mini_scores                                               mini_scores[]
+  counting_breaks                                           counting_breaks[]
 }
 
 model wordle_scores {


### PR DESCRIPTION
This PR should prevent the same user being able to break combos back to back, regardless of which counting game mode they originally broke the combo of.

UPDATE: This now should prevent the last 4 people to have broken the combo from breaking it again. It also fixes formatting issues in the warning before breaking a combo.

Fix #695.