### PR TITLE
Fix maximum length errors in "I need a tripsitter" modal

### DIFF
--- a/src/discord/utils/tripsitme.ts
+++ b/src/discord/utils/tripsitme.ts
@@ -1757,11 +1757,13 @@ export async function tripsitmeButton(
         .addComponents(new TextInputBuilder()
           .setCustomId('triageInput')
           .setLabel('What substance? How much taken? How long ago?')
+          .setMaxLength(120)
           .setStyle(TextInputStyle.Short)),
       new ActionRowBuilder<TextInputBuilder>()
         .addComponents(new TextInputBuilder()
           .setCustomId('introInput')
           .setLabel('What\'s going on? Give us the details!')
+          .setMaxLength(1100)
           .setStyle(TextInputStyle.Paragraph)),
     ));
 


### PR DESCRIPTION
Reduced "What did you take?" input to 120 chars and the rest of it to 1100. This leaves around 20-30 characters remaining. Couldn't find any other variables that could influence the size, so this seems fine. 

Fix #812.