### PR TITLE
chore: update express dependency to version 4.19.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "discord-api-types": "^0.37.67",
     "discord.js": "^14.14.1",
     "dotenv": "^16.4.1",
-    "express": "^4.18.2",
+    "express": "^4.19.2",
     "express-rate-limit": "^7.1.5",
     "fuse.js": "^7.0.0",
     "graphql-request": "^6.1.0",


### PR DESCRIPTION
Dependency npm:express:4.18.2 is vulnerable

Upgrade to 5.0.0-beta.3

CVE-2024-29041

Express.js minimalist web framework for node. Versions of Express.js prior to 4.19.0 and all pre-release alpha and beta versions of 5.0 are affected by an open redirect vulnerability using malformed URLs. When a user of Express performs a redirect using a user-provided URL Express performs an encode [using `encodeurl`](https://github.com/pillarjs/encodeurl) on the contents before passing it to the `location` header. This can cause malformed URLs to be evaluated in unexpected ways by common redirect allow list implementations in Express applications, leading to an Open Redirect via bypass of a properly implemented allow list. The main method impacted is `res.location()` but this is also called from within `res.redirect()`. The vulnerability is fixed in 4.19.2 and 5.0.0-beta.3.

