### PR TITLE
Fix null label in d.moderate.ts preventing mod actions on users with long names

### DIFF
--- a/src/discord/commands/guild/d.moderate.ts
+++ b/src/discord/commands/guild/d.moderate.ts
@@ -1864,7 +1864,11 @@ export async function modModal(
     .setCustomId('internalNote');
 
   try {
-    modalInputComponent.setLabel(`Why are you ${verb} ${target}?`);
+    // Ensure the label text is within the limit
+    const label = `Why are you ${verb} ${target}?`;
+    const truncatedLabelText = label.length > 45 ? `${label.substring(0, 41)}...?` : label;
+
+    modalInputComponent.setLabel(truncatedLabelText);
   } catch (err) {
     log.error(F, `Error: ${err}`);
     log.error(F, `Verb: ${verb}, Target: ${target}`);


### PR DESCRIPTION
Since the label failed to set due to the label being longer than 45 chars, the label was null/undefined and discord.js expected a string. Could be prevented in the future by doing checks on things that may exceed limits, and or handling the errors by setting a placeholder upon error.

Fix issue #824.