### PR TITLE
Fix broken mod tools from accidental WIP PR being merged

### DIFF
--- a/src/discord/commands/guild/d.moderate.ts
+++ b/src/discord/commands/guild/d.moderate.ts
@@ -1952,15 +1952,6 @@ export async function modModal(
         return;
       }
       await i.deferReply({ ephemeral: true });
-      if (isReport(command)) {
-        const reportResponseEmbed = embedTemplate()
-          .setColor(Colors.Yellow)
-          .setTitle('Report sent!')
-          .setDescription('The moderators have received your report and will look into it. Thanks!');
-        await i.editReply({
-          embeds: [reportResponseEmbed],
-        });
-      }
       // const internalNote = i.fields.getTextInputValue('internalNote'); // eslint-disable-line
 
       // // Only these commands actually have the description input, so only pull it if it exists
@@ -2052,9 +2043,7 @@ export async function modModal(
           // log.error(F, `Error: ${err}`);
         }
       }
-      if (!isReport) {
-        await i.editReply(await moderate(interaction, i));
-      }
+      await i.editReply(await moderate(interaction, i));
     })
     .catch(async err => {
       // log.error(F, `Error: ${JSON.stringify(err as DiscordErrorData, null, 2)}`);


### PR DESCRIPTION
In one of my previous PRs yesterday it would seem somehow a WIP PR I was simultaneously working on (report-fix branch) got added into main. Maybe I accidentally checked out from the wrong branch? This should remove the changes from that and on my end it restores mod tools back to their previous state, at the least, they do their job now.