### PR TITLE
Add moderators name to the end of internal ban reason.

### DIFF
--- a/src/discord/commands/guild/d.moderate.ts
+++ b/src/discord/commands/guild/d.moderate.ts
@@ -1502,6 +1502,10 @@ export async function moderate(
     );
   }
 
+  if (command === 'FULL_BAN') {
+    internalNote += `\n **Actioned by:** ${actor.displayName}`;
+  }
+
   let actionData = {
     user_id: targetData.id,
     guild_id: actor.guild.id,


### PR DESCRIPTION
Adds "\n Actioned by: modsname" to the end of the internal ban reason. This is added to the db entries and mod log / thread.

Fix #783.