### PR TITLE
Fix AI ToS spam

### DIFF
--- a/src/discord/commands/global/d.ai.ts
+++ b/src/discord/commands/global/d.ai.ts
@@ -1712,14 +1712,14 @@ async function agreeToTerms(
     embeds: [embedTemplate()
       .setTitle('🤖 Welcome to TripBot\'s AI Module! 🤖')
       .setDescription(`
-        Please agree to the following. Use \`/ai help\` for more more information.
+        Please agree to the following. Use \`/ai help\` for more information.
 
         ${termsOfService}
       `)
       .setFooter(null)],
     components: [
       new ActionRowBuilder<ButtonBuilder>().addComponents(
-        buttonAiAgree.setCustomId(`AI~messageAgree~${messageData.id}`),
+        buttonAiAgree.setCustomId(`AI~messageAgree~${messageData.author.id}`),
       ),
     ],
   };
@@ -2397,11 +2397,12 @@ export async function aiButton(
 ):Promise<void> {
   const buttonID = interaction.customId;
   log.debug(F, `buttonID: ${buttonID}`);
-  const [, buttonAction] = buttonID.split('~') as [
+  const [, buttonAction, messageAuthorId] = buttonID.split('~') as [
     null,
     'help' | 'personas' | 'setup' | 'agree' | 'privacy' |
     'link' | 'unlink' | 'messageAgree' | 'modify' | 'new' |
-    'create' | 'delete' | 'deleteConfirm' | 'deleteHistory' | 'deleteHistoryConfirm'];
+    'create' | 'delete' | 'deleteConfirm' | 'deleteHistory' | 'deleteHistoryConfirm',
+    string];
 
   // eslint-disable-next-line sonarjs/no-small-switch
   switch (buttonAction) {
@@ -2427,6 +2428,12 @@ export async function aiButton(
         },
       });
 
+      // const messageData = await interaction.message.fetchReference();
+
+      if (messageAuthorId !== interaction.user.id) {
+        log.debug(F, `${interaction.user.displayName} tried to accept the AI ToS using someone else's instance of the ToS.`);
+        return;
+      }
       await aiMessage(interaction.message);
       break;
     }


### PR DESCRIPTION
This PR will prevent people from accepting the AI ToS message if they did not trigger it themselves. Previously, if someone clicked the message and was not the original user who triggered it, they could make the bot spam replies to the original user.