### PR TITLE
Fix /say not working in in some text channels

### DIFF
--- a/src/discord/commands/guild/d.say.ts
+++ b/src/discord/commands/guild/d.say.ts
@@ -27,6 +27,10 @@ export const dSay: SlashCommand = {
       return false;
     }
 
+    if (!interaction.member) return false;
+
+    const member: GuildMember = interaction.member as GuildMember;
+
     const say = interaction.options.getString('say', true);
 
     let channel = interaction.options.getChannel('channel')
@@ -38,8 +42,24 @@ export const dSay: SlashCommand = {
       return false;
     }
 
+    // Ensure only moderators can use /say in announcements
+    if (
+      channel.type === ChannelType.GuildAnnouncement && 
+      !member.roles.cache.has(env.ROLE_MODERATOR)
+    ) {
+      await interaction.editReply({ content: 'Only moderators can use this command in announcement channels!' });
+      return false;
+    }
+
     // Ensure that the channel used is a text channel
-    if (channel.type !== ChannelType.GuildText) {
+    if (
+      channel.type !== ChannelType.GuildText &&
+      channel.type !== ChannelType.GuildVoice &&
+      channel.type !== ChannelType.PublicThread &&
+      channel.type !== ChannelType.PrivateThread &&
+      channel.type !== ChannelType.GuildAnnouncement &&
+      channel.type !== ChannelType.GuildForum
+    ) {
       await interaction.editReply({ content: 'This command can only be used in a server!' });
       return false;
     }
@@ -57,8 +77,8 @@ export const dSay: SlashCommand = {
 
     const channelBotlog = await interaction.guild.channels.fetch(env.CHANNEL_BOTLOG) as TextChannel;
     if (channelBotlog) {
-      await channelBotlog.send(`${(interaction.member as GuildMember).displayName} made me say '${say}' \
-in ${channel.name}`);
+      await channelBotlog.send(`${member.displayName} made me say '${say}' \
+        in ${channel.name}`);
     }
 
     return true;

--- a/src/discord/commands/guild/d.say.ts
+++ b/src/discord/commands/guild/d.say.ts
@@ -44,8 +44,8 @@ export const dSay: SlashCommand = {
 
     // Ensure only moderators can use /say in announcements
     if (
-      channel.type === ChannelType.GuildAnnouncement && 
-      !member.roles.cache.has(env.ROLE_MODERATOR)
+      channel.type === ChannelType.GuildAnnouncement
+      && !member.roles.cache.has(env.ROLE_MODERATOR)
     ) {
       await interaction.editReply({ content: 'Only moderators can use this command in announcement channels!' });
       return false;
@@ -53,12 +53,12 @@ export const dSay: SlashCommand = {
 
     // Ensure that the channel used is a text channel
     if (
-      channel.type !== ChannelType.GuildText &&
-      channel.type !== ChannelType.GuildVoice &&
-      channel.type !== ChannelType.PublicThread &&
-      channel.type !== ChannelType.PrivateThread &&
-      channel.type !== ChannelType.GuildAnnouncement &&
-      channel.type !== ChannelType.GuildForum
+      channel.type !== ChannelType.GuildText
+      && channel.type !== ChannelType.GuildVoice
+      && channel.type !== ChannelType.PublicThread
+      && channel.type !== ChannelType.PrivateThread
+      && channel.type !== ChannelType.GuildAnnouncement
+      && channel.type !== ChannelType.GuildForum
     ) {
       await interaction.editReply({ content: 'This command can only be used in a server!' });
       return false;


### PR DESCRIPTION
This PR makes /say work in all notable text channels. Only moderators can use it in #announcements though.