### PR TITLE
Fix missing equals symbol for RAPID_TOKEN in env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -54,7 +54,7 @@ GEMINI_KEY = <Optional>
 # Other API Tokens
 MOODLE_TOKEN = <Optional> # For Moodle API
 GITHUB_TOKEN = <Optional> # For GitHub API
-RAPID_TOKEN  <Optional> # For RapidAPI
+RAPID_TOKEN = <Optional> # For RapidAPI
 WOLFRAM_TOKEN = <Optional> # For WolframAlpha API
 IMGUR_ID = <Optional> # For Imgur API
 IMGUR_SECRET = <Optional> # For Imgur API


### PR DESCRIPTION
There is a missing equals symbol in the example env for RAPID_TOKEN. This should fix that. I may have introduced this in a previous PR by mistake, not sure.