### PR TITLE
Adding admin ability to overwrite user's experience data

### DIFF
--- a/src/discord/commands/guild/d.admin.ts
+++ b/src/discord/commands/guild/d.admin.ts
@@ -185,13 +185,13 @@ async function overwriteUserData(
   });
 
   if (!experienceData) {
-    console.log('No experience data found for the user.');
+    log.debug(F, `No experience data found for user ${userData.id} in category ${category} type ${type}.`);
     await interaction.editReply('Error: No experience data found for the user.');
     return;
   }
 
   const levelPoints = await findXPfromLevel(level);
-  console.log(`Updating category ${category} for user ${member.id} to level ${level} with ${levelPoints} points.`);
+  log.debug(F, `Overwriting user data for user ${userData.id} in category ${category} type ${type} to level ${level} with ${levelPoints} XP points.`);
 
   try {
     const result = await db.user_experience.updateMany({
@@ -206,9 +206,9 @@ async function overwriteUserData(
         total_points: levelPoints,
       },
     });
-    console.log(`Update result: ${JSON.stringify(result)}`); // Log the result of the update
+    console.log(`Update result: ${JSON.stringify(result)}`);
   } catch (error) {
-    console.error(`Error updating database: ${(error as Error).message}`); // Log any errors
+    console.error(`Error updating database: ${(error as Error).message}`);
   }
 
   await interaction.editReply(`User level and points updated for category ${category} to level ${level} with ${levelPoints} points.`);

--- a/src/discord/commands/guild/d.admin.ts
+++ b/src/discord/commands/guild/d.admin.ts
@@ -7,9 +7,9 @@ import {
 import axios from 'axios';
 import { stripIndents } from 'common-tags';
 import {
-  experience_category, experience_type, user_experience,
+  experience_category, experience_type,
 } from '@prisma/client';
-import { expForNextLevel, findXPfromLevel } from '../../../global/utils/experience';
+import { findXPfromLevel } from '../../../global/utils/experience';
 import { SlashCommand } from '../../@types/commandDef';
 import commandContext from '../../utils/context';
 import deployCommands from '../../utils/commandDeploy';

--- a/src/discord/commands/guild/d.admin.ts
+++ b/src/discord/commands/guild/d.admin.ts
@@ -6,6 +6,10 @@ import {
 } from 'discord.js';
 import axios from 'axios';
 import { stripIndents } from 'common-tags';
+import {
+  experience_category, experience_type, user_experience,
+} from '@prisma/client';
+import { expForNextLevel, findXPfromLevel } from '../../../global/utils/experience';
 import { SlashCommand } from '../../@types/commandDef';
 import commandContext from '../../utils/context';
 import deployCommands from '../../utils/commandDeploy';
@@ -144,6 +148,72 @@ async function setStatus(
   await interaction.editReply(`Status set to ${statusType} ${status}`);
 }
 
+async function overwriteUserData(
+  interaction: ChatInputCommandInteraction,
+): Promise<void> {
+  const member = interaction.options.getUser('user');
+  if (!member) {
+    await interaction.editReply('Error: User not found.');
+    return;
+  }
+
+  const category = interaction.options.getString('category') as experience_category;
+  const type = interaction.options.getString('type') as experience_type;
+  const level = interaction.options.getInteger('level');
+
+  if (!category || !type || level === null) {
+    await interaction.editReply('Error: Missing category, type, or level.');
+    return;
+  }
+
+  const userData = await db.users.upsert({
+    where: {
+      discord_id: member.id,
+    },
+    create: {
+      discord_id: member.id,
+    },
+    update: {},
+  });
+
+  const experienceData = await db.user_experience.findFirst({
+    where: {
+      user_id: userData.id,
+      category,
+      type,
+    },
+  });
+
+  if (!experienceData) {
+    console.log('No experience data found for the user.');
+    await interaction.editReply('Error: No experience data found for the user.');
+    return;
+  }
+
+  const levelPoints = await findXPfromLevel(level);
+  console.log(`Updating category ${category} for user ${member.id} to level ${level} with ${levelPoints} points.`);
+
+  try {
+    const result = await db.user_experience.updateMany({
+      where: {
+        user_id: userData.id,
+        category,
+        type,
+      },
+      data: {
+        level,
+        level_points: levelPoints,
+        total_points: levelPoints,
+      },
+    });
+    console.log(`Update result: ${JSON.stringify(result)}`); // Log the result of the update
+  } catch (error) {
+    console.error(`Error updating database: ${(error as Error).message}`); // Log any errors
+  }
+
+  await interaction.editReply(`User level and points updated for category ${category} to level ${level} with ${levelPoints} points.`);
+}
+
 export const dAdmin: SlashCommand = {
   data: new SlashCommandBuilder()
     .setName('admin')
@@ -187,12 +257,37 @@ export const dAdmin: SlashCommand = {
       .addStringOption(option => option
         .setName('url')
         .setDescription('The URL of the banner')
-        .setRequired(true))),
+        .setRequired(true)))
+    .addSubcommand(subcommand => subcommand
+      .setName('overwriteuserdata')
+      .setDescription('Overwrite user data')
+      .addUserOption(option => option.setName('user').setDescription('The user to update').setRequired(true))
+      .addStringOption(option => option.setName('category')
+        .setDescription('The category to update')
+        .setRequired(true)
+        .addChoices(
+          { name: 'General', value: 'GENERAL' },
+          { name: 'Tripsitter', value: 'TRIPSITTER' },
+          { name: 'Developer', value: 'DEVELOPER' },
+          { name: 'Team', value: 'TEAM' },
+          { name: 'Ignored', value: 'IGNORED' },
+          // Add more categories as needed
+        ))
+      .addStringOption(option => option.setName('type')
+        .setDescription('The type to update')
+        .setRequired(true)
+        .addChoices(
+          { name: 'Text', value: 'TEXT' },
+          { name: 'Voice', value: 'VOICE' },
+          // Add more types as needed
+        ))
+      .addIntegerOption(option => option.setName('level').setDescription('The level to set').setRequired(true))),
+
   async execute(interaction) {
     if (!interaction.channel) return false;
     if (!interaction.guild) return false;
     log.info(F, await commandContext(interaction));
-    const command = interaction.options.getSubcommand() as 'restart' | 'rebuild' | 'deploy' | 'setstatus' | 'setavatar' | 'setbanner';
+    const command = interaction.options.getSubcommand() as 'restart' | 'rebuild' | 'deploy' | 'setstatus' | 'setavatar' | 'setbanner' | 'overwriteuserdata';
     // By default we want to make the reply private
     await interaction.deferReply({ ephemeral: true });
     // eslint-disable-next-line sonarjs/no-small-switch
@@ -219,6 +314,10 @@ export const dAdmin: SlashCommand = {
       }
       case 'setstatus': {
         await setStatus(interaction, interaction.options.getString('prefix') as string, interaction.options.getString('status') as string);
+        break;
+      }
+      case 'overwriteuserdata': {
+        await overwriteUserData(interaction);
         break;
       }
       default: {

--- a/src/global/utils/experience.ts
+++ b/src/global/utils/experience.ts
@@ -33,11 +33,22 @@ const announcementEmojis = [
   '🎇',
 ];
 
-export async function expForNextLevel(
-  level:number,
-):Promise<number> {
+export async function expForNextLevel(level: number): Promise<number> {
   // This is a simple formula, making sure it's standardized across the system
   return 5 * (level ** 2) + (50 * level) + 100;
+}
+
+export async function findXPfromLevel(level: number): Promise<number> {
+  let totalXP = 0;
+
+  const xpPromises = [];
+  for (let currentLevel = 1; currentLevel < level; currentLevel += 1) {
+    xpPromises.push(expForNextLevel(currentLevel));
+  }
+  const xpResults = await Promise.all(xpPromises);
+  totalXP = xpResults.reduce((acc, xp) => acc + xp, 0);
+
+  return totalXP;
 }
 
 export async function getTotalLevel(


### PR DESCRIPTION
Main use case for this is to salvage people's lost xp after losing an account for whatever reason. Not a perfect solution but far less error prone and easier to operate than something like a full export/import of user data. For moonbear and hipperooni use only.