### PR TITLE
Add welcome emoji(s) to welcome messages

### DIFF
--- a/src/discord/utils/trust.ts
+++ b/src/discord/utils/trust.ts
@@ -168,13 +168,16 @@ but they were already marked at trusted in the database, so no message was sent`
       const greeting = greetingList[Math.floor(Math.random() * greetingList.length)];
 
       const channelLounge = await newMember.client.channels.fetch(env.CHANNEL_LOUNGE) as TextChannel;
-      await channelLounge.send({
+      const message = await channelLounge.send({
         content: stripIndents`**${greeting}**
       Head to <#${env.CHANNEL_TRIPSIT}> if you need a tripsitter. :)
       Be safe, have fun, and don't forget to visit the <id:guide> for more information!
 
       *${await topic()}*`,
       });
+
+      await message.react('<:ts_welcomeA:1222543903677485156>');
+      await message.react('<:ts_welcomeB:1222543905216663634>');
 
       await db.members.upsert({
         where: {

--- a/src/discord/utils/trust.ts
+++ b/src/discord/utils/trust.ts
@@ -176,8 +176,12 @@ but they were already marked at trusted in the database, so no message was sent`
       *${await topic()}*`,
       });
 
-      await message.react('<:ts_welcomeA:1222543903677485156>');
-      await message.react('<:ts_welcomeB:1222543905216663634>');
+      try {
+        await message.react('<:ts_welcomeA:1222543903677485156>');
+        await message.react('<:ts_welcomeB:1222543905216663634>');
+      } catch (err) {
+        log.debug(F, 'Attempted to add welcome emojis to welcome message, but they appear to be missing.');
+      }
 
       await db.members.upsert({
         where: {


### PR DESCRIPTION
Adds two welcome emojis to the welcome message when someone joins. Part A and B since we don't have a single one, and even if we did, I think it would be too smol to be readable.

Resolves #760 