### PR TITLE
Add max length for tech help modal

### DIFF
--- a/src/discord/utils/techHelp.ts
+++ b/src/discord/utils/techHelp.ts
@@ -80,7 +80,7 @@ export async function techHelpClick(interaction:ButtonInteraction) {
       .setCustomId(`${issueType}IssueInput`)
       .setRequired(true)
       .setMinLength(10)
-      .setMaxLength(2000))));
+      .setMaxLength(1800))));
 
   const filter = (i:ModalSubmitInteraction) => i.customId.includes('techHelpSubmit');
   interaction.awaitModalSubmit({ filter, time: 0 })


### PR DESCRIPTION
Prevents errors when the ticket details are too long. This and tripsitme are the only two I'm aware of. Other one was resolved a few months back.

Resolves #468.