### PR TITLE
Add temporary bans & fix unmute not unmuting

### DIFF
--- a/src/discord/commands/guild/d.moderate.ts
+++ b/src/discord/commands/guild/d.moderate.ts
@@ -1393,9 +1393,9 @@ export async function moderate(
   if (isTimeout(command)) {
     // log.debug(F, 'Parsing timeout duration');
     let durationVal = modalInt.fields.getTextInputValue('duration');
-    if (durationVal === '') durationVal = '7 days';
+    if (durationVal === '') durationVal = '7d';
 
-    if (durationVal !== '' && !validateDurationInput(durationVal)) {
+    if (!validateDurationInput(durationVal)) {
       return {
         content: 'Timeout duration must include at least one of seconds, minutes, hours, days, or a week. For example: 5d 5h 5m 5s, 1w or 5d.',
       };
@@ -1422,7 +1422,7 @@ export async function moderate(
         return { content: 'Ban duration must be a number!' };
       }
 
-      if (durationVal !== '' && !validateDurationInput(durationVal)) {
+      if (!validateDurationInput(durationVal)) {
         return {
           content: 'Ban duration must include at least one of seconds, minutes, hours, days, weeks, months, or years. For example: 1yr 1M 1w 1d 1h 1m 1s',
         };

--- a/src/global/utils/parseDuration.ts
+++ b/src/global/utils/parseDuration.ts
@@ -12,7 +12,7 @@ export default parseDuration;
 export async function parseDuration(duration:string):Promise<number> {
   // Those code inspired by https://gist.github.com/substanc3-dev/306bb4d04b2aad3a5d019052b1a0dec0
   // This is super cool, thanks a lot!
-  const supported = 'smhdwmoy';
+  const supported = 'smMhdwmoy';
   const numbers = '0123456789';
   let stage = 1;
   let idx = 0;
@@ -53,7 +53,7 @@ export async function parseDuration(duration:string):Promise<number> {
           if (c === 'h') {
             timeValue += tempNumber * 60 * 60 * 1000;
           }
-          if (c === 'mo') {
+          if (c === 'M') {
             timeValue += tempNumber * 30 * 24 * 60 * 60 * 1000;
           }
           if (c === 'm') {
@@ -81,3 +81,8 @@ export async function parseDuration(duration:string):Promise<number> {
   }
   return timeValue;
 }
+
+export const validateDurationInput = (input: string): boolean => {
+  const regex = /^(\d+(yr|M|w|d|h|m|s)\s?)+$/;
+  return regex.test(input.trim());
+};

--- a/src/global/utils/timer.ts
+++ b/src/global/utils/timer.ts
@@ -1159,17 +1159,6 @@ async function undoExpiredBans() {
               },
             });
           }
-
-          try {
-            await user.send(stripIndents`Hi ${user.username},  
-              Your temporary ban from TripSit has been lifted! You're welcome to rejoin the community whenever you're ready.  
-              
-              We really appreciate your understanding during this time and look forward to seeing you back.  
-              
-              If you decide to rejoin, please take a moment to review the #rules channel. Hope to see you around soon!`);
-          } catch (err) {
-            // Do nothing. It's likely their discord permissions disallowed the bot to ever have comms with them.
-          }
         }
       }
     });

--- a/src/prisma/tripbot/migrations/20241222102954_add_ban_duration_field/migration.sql
+++ b/src/prisma/tripbot/migrations/20241222102954_add_ban_duration_field/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "users" ADD COLUMN     "discord_bot_ban_expires_at" TIMESTAMPTZ(6);

--- a/src/prisma/tripbot/migrations/20241222102954_add_ban_duration_field/migration.sql
+++ b/src/prisma/tripbot/migrations/20241222102954_add_ban_duration_field/migration.sql
@@ -1,2 +1,0 @@
--- AlterTable
-ALTER TABLE "users" ADD COLUMN     "discord_bot_ban_expires_at" TIMESTAMPTZ(6);

--- a/src/prisma/tripbot/migrations/20241223220041_user_actions_target_id/migration.sql
+++ b/src/prisma/tripbot/migrations/20241223220041_user_actions_target_id/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "user_actions" ADD COLUMN     "target_discord_id" TEXT;

--- a/src/prisma/tripbot/schema.prisma
+++ b/src/prisma/tripbot/schema.prisma
@@ -134,6 +134,7 @@ model users {
   move_points                                               Int                  @default(0)
   empathy_points                                            Int                  @default(0)
   discord_bot_ban                                           Boolean              @default(false)
+  discord_bot_ban_expires_at                                DateTime?            @db.Timestamptz(6)
   ticket_ban                                                Boolean              @default(false)
   last_seen_at                                              DateTime             @default(now()) @db.Timestamptz(6)
   last_seen_in                                              String?

--- a/src/prisma/tripbot/schema.prisma
+++ b/src/prisma/tripbot/schema.prisma
@@ -134,7 +134,6 @@ model users {
   move_points                                               Int                  @default(0)
   empathy_points                                            Int                  @default(0)
   discord_bot_ban                                           Boolean              @default(false)
-  discord_bot_ban_expires_at                                DateTime?            @db.Timestamptz(6)
   ticket_ban                                                Boolean              @default(false)
   last_seen_at                                              DateTime             @default(now()) @db.Timestamptz(6)
   last_seen_in                                              String?
@@ -360,6 +359,7 @@ model rpg_inventory {
 model user_actions {
   id                                                 String           @id @default(dbgenerated("uuid_generate_v4()")) @db.Uuid
   user_id                                            String           @db.Uuid
+  target_discord_id                                  String?
   guild_id                                           String           @default("179641883222474752")
   type                                               user_action_type
   ban_evasion_related_user                           String?          @db.Uuid


### PR DESCRIPTION
Moderators can now temporarily ban someone and it will expire after the time is up. By default these expiring bans are only checked once per day but this can be adjusted if there is any valid reason to check anymore frequently.

The duration works the same as the timeout duration. To permanently ban someone as normal, just leave the input empty.
  
While working on this I discovered that unmuting someone / removing them from time out did not actually work and so it's fixed in this PR as well.