### PR TITLE
Make ban expirations go to mod thread, mod log, and makes temp bans functional across all guilds.

### DIFF
--- a/src/global/utils/timer.ts
+++ b/src/global/utils/timer.ts
@@ -1150,28 +1150,28 @@ async function undoExpiredBans() {
             if (targetGuild.id === env.DISCORD_GUILD_ID) {
               const targetUser = await discordClient.users.fetch(activeBan.target_discord_id);
               const modlog = await targetGuild.channels.fetch(env.CHANNEL_MODLOG) as TextChannel;
-            
+
               // Ensure created_at and expires_at are valid before using them
               if (activeBan.created_at && activeBan.expires_at) {
                 const createdAt = new Date(activeBan.created_at);
                 const expiresAt = new Date(activeBan.expires_at);
-            
+
                 const durationMs = expiresAt.getTime() - createdAt.getTime(); // Duration in milliseconds
-            
+
                 // Convert the duration from milliseconds to days
                 const days = Math.floor(durationMs / (1000 * 60 * 60 * 24));
-            
+
                 // Build the duration string
-                let durationString = `${days} days`;
-            
+                const durationString = `${days} days`;
+
                 // Send the modlog message with the formatted duration
                 const modlogEmbed = embedTemplate()
                   .setColor(Colors.Green)
                   .setDescription(`${targetUser.username} (${activeBan.target_discord_id}) has been unbanned after ${durationString}`);
-                
+
                 await modlog.send({ embeds: [modlogEmbed] });
               } else {
-                console.error("Invalid ban timestamps:", activeBan.created_at, activeBan.expires_at);
+                log.error(F, 'Temporary ban is somehow missing created_at or expired_at');
               }
             }
           } catch (err) {

--- a/src/global/utils/timer.ts
+++ b/src/global/utils/timer.ts
@@ -1167,12 +1167,11 @@ async function undoExpiredBans() {
 
       const durationMs = new Date(activeBan.expires_at).getTime() - new Date(activeBan.created_at).getTime();
       const days = Math.floor(durationMs / (1000 * 60 * 60 * 24));
-      const durationString = `${days} days`;
 
       // Send messages
       const embed = embedTemplate()
         .setColor(Colors.Green)
-        .setDescription(`${user.username} (${activeBan.target_discord_id}) has been unbanned after ${durationString}`);
+        .setDescription(`${user.username} (${activeBan.target_discord_id}) has been unbanned after ${days} days`);
 
       if (modThread) await modThread.send({ embeds: [embed] });
       if (modlog) await modlog.send({ embeds: [embed] });

--- a/src/global/utils/timer.ts
+++ b/src/global/utils/timer.ts
@@ -1233,7 +1233,7 @@ async function runTimer() {
     { callback: checkMoodle, interval: env.NODE_ENV === 'production' ? seconds60 : seconds5 },
     // { callback: checkLpm, interval: env.NODE_ENV === 'production' ? seconds10 : seconds5 },
     { callback: updateDb, interval: env.NODE_ENV === 'production' ? hours24 : hours48 },
-    { callback: undoExpiredBans, interval: env.NODE_ENV === 'production' ? hours24 : seconds10 },
+    { callback: undoExpiredBans, interval: env.NODE_ENV === 'production' ? hours24 / 2 : seconds10 },
   ];
 
   timers.forEach(timer => {


### PR DESCRIPTION
This update expands the handling of expired temporary bans to support all guilds, not just the main TripSit guild. When a temporary ban expires, a notification is automatically sent to both the mod thread and mod log, detailing the user’s unban and the duration of the ban.

tl;dr should work on all guilds, mods can now see when a ban expires in both mod thread and mod-log.

Resolves #935.

EDIT: This also shortened the timer for this from 24h to 12h and made the unbans be processed in parallel 