### PR TITLE
Remove Sentry usage, blacklist team/bot roles from /role cmd

### DIFF
--- a/src/discord/commands/guild/d.role.ts
+++ b/src/discord/commands/guild/d.role.ts
@@ -49,6 +49,16 @@ const mindsetRoles = [
   { name: 'Sober', value: env.ROLE_SOBER },
 ] as RoleDef[];
 
+// Roles that only an Admin can add, therefor no one.
+const blacklistedRoles = [
+  env.ROLE_MODERATOR,
+  env.ROLE_TRIPSITTER,
+  env.ROLE_DEVELOPER,
+  env.ROLE_TRIPBOTDEV,
+  env.ROLE_TEAMTRIPSIT,
+  env.ROLE_TRIPBOT,
+  env.ROLE_BOT,
+];
 // log.debug(F, `Mindset roles: ${JSON.stringify(mindsetRoles, null, 2)}`);
 // const mindsetNames = mindsetRoles.map(role => role.name);
 const mindsetIds = mindsetRoles.map(role => role.value);
@@ -64,6 +74,8 @@ const safeRoleList = [
 //   ...mindsetRoles,
 //   ...premiumColorRoles,
 // ];
+
+const noPermissionText = 'You do not have permission to use that role!';
 
 export const dRole: SlashCommand = {
   data: new SlashCommandBuilder()
@@ -125,10 +137,17 @@ export const dRole: SlashCommand = {
 
     // log.debug(F, `isMod: ${isMod}, isTs: ${isTs}, isDonor: ${isDonor}, isPatron: ${isPatron}`);
 
+    // Prevent using blacklisted roles
+    if (blacklistedRoles.includes(role.id)) {
+      // log.debug(F, `role.id is ${role.id} and is blacklisted`);
+      await interaction.editReply({ content: noPermissionText });
+      return false;
+    }
+
     // If you're not a mod or tripsitter, you can't add anything that's not in the "safe" list
     if (!safeRoleList.includes(role.id) && !isMod && !isTs) {
       // log.debug(F, `role.id is ${role.id} and is not in the safe list. (isMod: ${isMod}, isTs: ${isTs})`);
-      await interaction.editReply({ content: 'You do not have permission to use that role!' });
+      await interaction.editReply({ content: noPermissionText });
       return false;
     }
 
@@ -136,7 +155,7 @@ export const dRole: SlashCommand = {
     if (premiumColorIds.includes(role.id) && !isMod && !isTs && !isDonor && !isPatron) {
       // log.debug(F, `role.id is ${role.id} is a premium role and the user is not premium
       // (isMod: ${isMod}, isTs: ${isTs} isDonor: ${isDonor}, isPatron: ${isPatron})`);
-      await interaction.editReply({ content: 'You do not have permission to use that role!' });
+      await interaction.editReply({ content: noPermissionText });
       return false;
     }
 

--- a/src/discord/events/error.ts
+++ b/src/discord/events/error.ts
@@ -7,7 +7,7 @@ import {
   MessageContextMenuCommandInteraction,
   UserContextMenuCommandInteraction,
 } from 'discord.js';
-import * as Sentry from '@sentry/node';
+// import * as Sentry from '@sentry/node';
 import { ErrorEvent } from '../@types/eventDef';
 
 const F = f(__filename);
@@ -53,8 +53,10 @@ export default async function handleError(
 
   // If this is production, send a message to the channel and alert the developers
   if (env.NODE_ENV === 'production') {
+    /* Uncomment this if you want to use Sentry
+
     if (interaction) {
-      log.debug(F, 'Interaction found, sending error to GlitchTip');
+      log.debug(F, 'Interaction found, sending error to Sentry');
       Sentry.captureException(errorData, {
         tags: {
           command: commandName,
@@ -66,11 +68,11 @@ export default async function handleError(
         },
       });
     } else {
-      log.debug(F, 'No interaction, sending error to GlitchTip');
+      log.debug(F, 'No interaction, sending error to Sentry');
       Sentry.captureException(errorData);
-    }
+    } */
     if (interaction) {
-      // log.debug(F, 'Interaction found, sending error to rollbar');
+      log.debug(F, 'Interaction found, sending error to rollbar');
       global.rollbar.error(errorStack, {
         tags: {
           command: commandName,
@@ -82,7 +84,7 @@ export default async function handleError(
         },
       });
     } else {
-      // log.debug(F, 'No interaction, sending error to rollbar');
+      log.debug(F, 'No interaction, sending error to rollbar');
       global.rollbar.error(errorStack);
     }
 


### PR DESCRIPTION
Remove Sentry since we don't actually use it and fix the /role command from being able to add/remove Team roles. Currently, anyone with /role access could add/remove team roles from anyone regardless if the role is equal to or above their current permissions level.