### PR TITLE
Allow mods to mod tents while not connected + perms fixes

### DIFF
--- a/src/discord/utils/tents.ts
+++ b/src/discord/utils/tents.ts
@@ -51,6 +51,7 @@ export async function pitchTent(
       {
         id: New.member.id,
         allow: [
+          PermissionsBitField.Flags.ViewChannel,
           PermissionsBitField.Flags.Connect,
           PermissionsBitField.Flags.MoveMembers,
         ],
@@ -100,7 +101,7 @@ export async function pitchTent(
   - \`/tent name\` - Set a new name for your tent
   - \`/tent limit\` - Set a user limit
   - \`/tent level\` - Set a level requirement
-  - \`/tent lock\`- Prevents anyone else from joining
+  - \`/tent lock\`- Locks channel for all
 
 - **Moderate your tent**
   - \`/tent add\` - Allow a user to join and see your tent, regardless of other settings


### PR DESCRIPTION
Mods can now moderate any tent even without being connected by using /tent commands inside the tent's text chat.

Also made small updates to ensure added users and the host can join if the tent has a level requirement set