### PR TITLE
Disable rectal ketamine in /calc ketamine response

### DIFF
--- a/src/discord/commands/global/d.calc.ts
+++ b/src/discord/commands/global/d.calc.ts
@@ -133,12 +133,12 @@ async function dCalcKetamine(
       name: 'Insufflated',
       value: stripIndents`${data.insufflated}`,
       inline: true,
-    },
+    }, /* Uncomment this when we've implemented a better boofing calculation method
     {
       name: 'Rectal',
       value: stripIndents`${data.rectal}`,
       inline: true,
-    },
+    }, */
   );
   return embed;
 }


### PR DESCRIPTION
It's inaccurate. We will re-enable once we have a better calculation method. 

Resolves #993.