### PR TITLE
Add "time until error" log to AI error response

### DIFF
--- a/src/discord/commands/global/d.ai.ts
+++ b/src/discord/commands/global/d.ai.ts
@@ -2187,8 +2187,13 @@ export async function aiMessage(
     clearInterval(typingInterval); // Stop sending typing indicator
   }, 30000); // Failsafe to stop typing indicator after 30 seconds
 
+  let differenceInMs = 0;
   try {
+    const startTime = Date.now();
     const chatResponse = await handleAiMessageQueue(aiPersona, messageList, messageData, attachmentInfo);
+    const endTime = Date.now();
+    differenceInMs = endTime - startTime;
+    log.debug(F, `AI response took ${differenceInMs}ms`);
     response = chatResponse.response;
     promptTokens = chatResponse.promptTokens;
     completionTokens = chatResponse.completionTokens;
@@ -2259,10 +2264,13 @@ export async function aiMessage(
     // const sleepTime = (wordCount / wpm) * 60000;
     // // log.debug(F, `Typing ${wordCount} at ${wpm} wpm will take ${sleepTime / 1000} seconds`);
     // await sleep(sleepTime > 10000 ? 5000 : sleepTime); // Don't wait more than 5 seconds
+
     if (response.length === 0) {
-      response = stripIndents`This is unexpected, but somehow I don't appear to have anything to say! 
-      By the way, this is an error message and something went wrong. Please try again.`;
+      response = stripIndents`This is unexpected but somehow I don't appear to have anything to say! 
+      By the way, this is an error message and something went wrong. Please try again.
+      Time from query to error: ${(differenceInMs / 1000).toFixed(2)} seconds`;
     }
+
     const replyMessage = await messageData.reply({
       content: response.slice(0, 2000),
       allowedMentions: { parse: [] },


### PR DESCRIPTION
To help figure out why we keep getting empty responses from ChatGPT often 10 minutes after the question.  
  
May have to do with my queuing system, or it may be GPT being slow/down for 10 minutes. Idk.  
  
If it's just down for a long time then my solution will be to not even reply if the response took longer than 60 seconds.