### PR TITLE
Fix ModerateHatespeech triggering in internal team channels.

### DIFF
--- a/src/discord/events/messageCreate.ts
+++ b/src/discord/events/messageCreate.ts
@@ -93,7 +93,9 @@ export const messageCreate: MessageCreateEvent = {
     helperActivityUpdate(message);
     // discordAiModerate(message);
     nightsWatch(message);
-    monitorToxicity(message);
+    if ('parentId' in message.channel && message.channel.parentId !== env.CATEGORY_TEAMTRIPSIT) {
+      monitorToxicity(message);
+    }
 
     // Disabled for testing
     // thoughtPolice(message);


### PR DESCRIPTION
MH was triggering in internal team channels resulting in some messages ending up in ai-mod-log.