### PR TITLE
Fix HR threads staying after 5 day limit due to system messages.

### DIFF
--- a/src/global/utils/timer.ts
+++ b/src/global/utils/timer.ts
@@ -323,7 +323,7 @@ async function checkTickets() { // eslint-disable-line @typescript-eslint/no-unu
           archived: {
             type: 'private',
             fetchAll: true,
-            before: new Date().setDate(new Date().getDate() - 7),
+            before: new Date().setDate(new Date().getDate() - 5),
           },
         });
         // const threadList = await channel.threads.fetchArchived({ type: 'private', fetchAll: true });
@@ -333,14 +333,15 @@ async function checkTickets() { // eslint-disable-line @typescript-eslint/no-unu
           try {
             await thread.fetch();
 
-            // Get the last message sent int he thread
-            const messages = await thread.messages.fetch({ limit: 1 });
-            const lastMessage = messages.first();
+            // Get messages and filter out system messages
+            const messages = await thread.messages.fetch({ limit: 10 }); // Fetch more to account for system messages
+            const userMessages = messages.filter(msg => !msg.system);
+            const lastUserMessage = userMessages.first();
 
             // Determine if this message was sent longer than a week ago
-            if (lastMessage && DateTime.fromJSDate(lastMessage.createdAt) >= DateTime.local().minus({ days: 5 })) {
+            if (lastUserMessage && DateTime.fromJSDate(lastUserMessage.createdAt) >= DateTime.local().minus({ days: 5 })) {
               thread.delete();
-              log.debug(F, `Deleted thread ${thread.name} in ${channel.name} because the last message was sent over 5 days ago`);
+              log.debug(F, `Deleted thread ${thread.name} in ${channel.name} because the last user message was sent over 5 days ago`);
             }
           } catch (err) {
             // Thread was likely manually deleted

--- a/src/global/utils/timer.ts
+++ b/src/global/utils/timer.ts
@@ -122,7 +122,7 @@ async function checkTickets() { // eslint-disable-line @typescript-eslint/no-unu
         const updatedTicket = ticket;
         updatedTicket.status = 'ARCHIVED' as ticket_status;
         updatedTicket.deleted_at = env.NODE_ENV === 'production'
-          ? DateTime.local().plus({ days: 2 }).toJSDate()
+          ? DateTime.local().plus({ days: 3 }).toJSDate()
           : DateTime.local().plus({ minutes: 1 }).toJSDate();
         if (!updatedTicket.description) {
           updatedTicket.description = 'Ticket archived';


### PR DESCRIPTION
Also fixes left over 7 day fetch from before we shortened thread life cycles to 5 days for deletion & 3 for archive/closing.  
  
And another which was set to 2 days when it should have been 3.