### PR TITLE
Fix char limit issues & rare acknowledgement issue

### DIFF
--- a/src/discord/utils/modUtils.ts
+++ b/src/discord/utils/modUtils.ts
@@ -1506,11 +1506,6 @@ export async function acknowledgeReportButton(
       await modLog.send({
         embeds: [successEmbed],
       });
-      // eslint-disable-next-line sonarjs/no-nested-template-literals
-      log.info(F, `All mentioned users:${buttonInt.message.mentions.users.map(u => `${u.username} (${u.id})`)}`);
-      log.info(F, `First mentioned user (reporterId):${reporterUser.id}`);
-      // eslint-disable-next-line no-nested-ternary
-      log.info(F, `TargetId from button:${reporteeMember ? reporteeMember.id : (reporterUser ? reporteeUser?.id : 'unknown')} `);
       return;
     }
 


### PR DESCRIPTION
Fix 1000 char limit being hit on mod actions if using report message on a large message. Fix acknowledgements sometimes sending to the reportee if both reporter & reportee had their name start with the same text.  
  
Instead of getting reporter by mentions in the mod thread, we send it through the button ID instead alongside the reportee. Idk why I didn't do that the first time.  
  
Fix #1067 