### PR TITLE
 Fix unhandled Unknown Message crash in pagination collector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,3 +379,5 @@ assets/data/combinedDB.json
 assets/data/tripsitCombos.json
 assets/data/tripsitDB.json
 .eslintcache
+CLAUDE.md
+.prettierrc

--- a/.gitignore
+++ b/.gitignore
@@ -380,4 +380,3 @@ assets/data/tripsitCombos.json
 assets/data/tripsitDB.json
 .eslintcache
 CLAUDE.md
-.prettierrc

--- a/src/discord/utils/pagination.ts
+++ b/src/discord/utils/pagination.ts
@@ -104,6 +104,8 @@ export async function paginationEmbed(
           pages[page].setFooter({ text: `Page ${page + 1} / ${pages.length}` }),
         ],
         components: [disabledRow],
+      }).catch(() => {
+        // Message was deleted before the collector timed out — nothing to disable.
       });
     }
   });


### PR DESCRIPTION
  Attach a .catch() to the button-disabling edit in src/discord/utils/pagination.ts so a deleted message no
  longer crashes the process. This mirrors the existing defensive handling already present for the similar edit
  in d.busyness.ts.