### PR TITLE
Vendor and Bot banning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -379,3 +379,4 @@ assets/data/combinedDB.json
 assets/data/tripsitCombos.json
 assets/data/tripsitDB.json
 .eslintcache
+CLAUDE.md

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,8 @@
   // --- AUTOFIX & FORMATTING ---
   "editor.formatOnSave": true,
   "editor.defaultFormatter": "dbaeumer.vscode-eslint",
+  // Prettier is intentionally disabled on this project — ESLint is the formatter.
+  "prettier.enable": false,
   "editor.codeActionsOnSave": {
     "source.fixAll.eslint": "explicit",
     "source.addMissingImports": "explicit",
@@ -65,6 +67,12 @@
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   "[javascriptreact]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
+  "[typescriptreact]": {
     "editor.defaultFormatter": "dbaeumer.vscode-eslint"
   },
   "[markdown]": {

--- a/src/discord/utils/modUtils.ts
+++ b/src/discord/utils/modUtils.ts
@@ -411,6 +411,21 @@ export const modButtonBan = (discordId: string) => new ButtonBuilder()
   .setEmoji('🔨')
   .setStyle(ButtonStyle.Danger);
 
+// Quick-ban shortcuts: open the normal full-ban modal pre-filled (reason + 7-day purge, no
+// user message). The `~vendor`/`~bot` segment is read in modModal to drive the prefill, and
+// the prefilled reason ('Vendor'/'Bot') triggers the existing isVendorBotBan no-DM behavior.
+export const modButtonBanVendor = (discordId: string) => new ButtonBuilder()
+  .setCustomId(`moderate~FULL_BAN~${discordId}~vendor`)
+  .setLabel('Vendor')
+  .setEmoji('🪧')
+  .setStyle(ButtonStyle.Danger);
+
+export const modButtonBanBot = (discordId: string) => new ButtonBuilder()
+  .setCustomId(`moderate~FULL_BAN~${discordId}~bot`)
+  .setLabel('Bot')
+  .setEmoji('🤖')
+  .setStyle(ButtonStyle.Danger);
+
 export const modButtonUnBan = (discordId: string) => new ButtonBuilder()
   .setCustomId(`moderate~UN-FULL_BAN~${discordId}`)
   .setLabel('Unban')
@@ -1048,6 +1063,8 @@ export async function modResponse(
     timeoutTime = target.communicationDisabledUntilTimestamp;
   }
 
+  // Second row of mod buttons — the primary row maxes out at 5 components.
+  const quickBanRow = new ActionRowBuilder<ButtonBuilder>();
   if (showModButtons) {
     if (isInfo(command) || isReport(command)) {
       actionRow.addComponents(
@@ -1056,6 +1073,10 @@ export async function modResponse(
         modButtonTimeout(target.id),
         modButtonBan(target.id),
         modButtonInfo(target.id),
+      );
+      quickBanRow.addComponents(
+        modButtonBanVendor(target.id),
+        modButtonBanBot(target.id),
       );
     } else if (isTimeout(command) || (timeoutTime && timeoutTime > Date.now())) {
       actionRow.addComponents(
@@ -1104,18 +1125,22 @@ export async function modResponse(
 
   log.debug(F, `[modResponse] time: ${Date.now() - startTime}ms`);
 
+  const components = quickBanRow.components.length > 0
+    ? [actionRow, quickBanRow]
+    : [actionRow];
+
   if (showModButtons && !actorIsMod && isReport(command)) {
     const actionRowTwo = new ActionRowBuilder<ButtonBuilder>();
     actionRowTwo.addComponents(modButtonAcknowledgeReport(target.id, actor.id));
     return {
       embeds: [modlogEmbed],
-      components: [actionRow, actionRowTwo],
+      components: [...components, actionRowTwo],
     };
   }
 
   return {
     embeds: [modlogEmbed],
-    components: [actionRow],
+    components,
   };
 }
 
@@ -2203,7 +2228,7 @@ export async function modModal(
   interaction: ButtonInteraction,
 ): Promise<void> {
   if (!interaction.guild) return;
-  const [, cmd, userId] = interaction.customId.split('~');
+  const [, cmd, userId, variant] = interaction.customId.split('~');
   const command: ModAction = cmd.toUpperCase() as ModAction;
 
   let target: string = userId;
@@ -2273,6 +2298,7 @@ export async function modModal(
 
   let modalInternal = '';
   let modalDescription = '';
+  let modalDays = '';
   const embed = interaction.message.embeds[0].toJSON();
 
   // Try to handle AI mod stuff
@@ -2322,6 +2348,14 @@ export async function modModal(
       ${messageWithoutUrl.substring(0, 830)} \n> ${extractedUrl}`;
   } catch (err) {
     // log.error(F, `Error: ${err}`);
+  }
+
+  // Quick vendor/bot ban shortcut: prefill the reason + a 1-day message purge and leave the
+  // user-facing message blank. The 'Vendor'/'Bot' reason triggers isVendorBotBan (no DM).
+  if (isFullBan(command) && (variant === 'vendor' || variant === 'bot')) {
+    modalInternal = variant === 'vendor' ? 'Vendor' : 'Suspected bot';
+    modalDescription = '';
+    modalDays = '1 day';
   }
 
   let verb = '';
@@ -2404,6 +2438,7 @@ export async function modModal(
         .setLabel('How far back should messages be removed?')
         .setStyle(TextInputStyle.Short)
         .setPlaceholder('7 days or 1 week, etc. (Max 7 days, Default 0 days)')
+        .setValue(modalDays)
         .setRequired(false)
         .setCustomId('days')));
     modal.addComponents(new ActionRowBuilder<TextInputBuilder>()

--- a/src/discord/utils/modUtils.ts
+++ b/src/discord/utils/modUtils.ts
@@ -84,6 +84,11 @@ const noReason = 'No reason provided';
 // const descriptionPlaceholder = 'Tell the user why you\'re doing this';
 const mepWarning = 'You cannot use the word "MEP" here.';
 const noMessageSent = '*No message sent to user*';
+
+// Internal-note keywords that mark a vendor/bot ban. Full bans whose internal
+// note contains one of these (as a whole word, optionally plural) never DM the user.
+const noDmBanKeywords = ['vendor', 'bot'] as const;
+const noDmBanKeywordRegex = new RegExp(`\\b(${noDmBanKeywords.join('|')})s?\\b`, 'i');
 /*
 const cooperativeExplanation = stripIndents`This is a suite of moderation tools for guilds to use, \
 this includes the ability to ban, warn, report, and more!
@@ -1246,8 +1251,9 @@ export async function messageModThread(
   }
 
   let modThread = null as ThreadChannel | null;
-  const vendorBan = internalNote?.toLowerCase().includes('vendor') && isFullBan(command);
-  if (!vendorBan) {
+  const isVendorBotBan = isFullBan(command)
+    && noDmBanKeywordRegex.test(internalNote ?? '');
+  if (!isVendorBotBan) {
     const guild = await discordClient.guilds.fetch(guildData.id);
     if (targetData.mod_thread_id) {
       // log.debug(F, `Mod thread id exists: ${targetData.mod_thread_id}`);
@@ -1730,8 +1736,9 @@ export async function moderate(
   }
   let internalNote = modalInt.fields.getTextInputValue('internalNote');
 
-  // Check if this is a vendor ban
-  const vendorBan = internalNote?.toLowerCase().includes('vendor') && isFullBan(command);
+  // Check if this is a vendor/bot ban (none of these should DM the user)
+  const isVendorBotBan = isFullBan(command)
+    && noDmBanKeywordRegex.test(internalNote ?? '');
 
   // Don't allow people to mention MEP
   if (internalNote?.includes('MEP') || description?.includes('MEP')) {
@@ -1857,7 +1864,7 @@ export async function moderate(
   }
 
   if (sendsMessageToUser(command)
-    && !vendorBan
+    && !isVendorBotBan
     && (description !== '' && description !== null)
     && (targetMember || targetUser)) {
     log.debug(F, `[moderate] Sending message to ${targetName}`);
@@ -2177,7 +2184,7 @@ export async function moderate(
   const desc = stripIndents`
     ${anonSummary}
     **Reason:** ${internalNote ?? noReason}
-     ${(description !== '' && description !== null && !vendorBan && targetMember) ? `\n\n**Note sent to user: ${description}**` : ''}
+     ${(description !== '' && description !== null && !isVendorBotBan && targetMember) ? `\n\n**Note sent to user: ${description}**` : ''}
   `;
 
   const response = embedTemplate()


### PR DESCRIPTION
When a vendor is banned, certain processes, like sending the user a DM or creating a mod thread, are ignored. The same logic has been applied to when a mod user bans a bot (makes sense and was also requested). This change sees that vendors and bots are treated exactly the same when a ban action is applied.

Secondly, when a mod uses the report slash command, two new buttons - Vendor and Bot - have been added. Clicking on one or the other will still open the mod modal, but the ban reason and message delete days are pre-filled. This makes the banning of vendors and bots a bit faster and was met with approval when brought up with the mod team.

Considering maybe skipping the mod modal for vendor / bot bans in the future, but this comes with a few risks and would need to be fleshed out more.