### PR TITLE
Added Tent "State" iconography

### DIFF
--- a/src/discord/commands/guild/d.voice.ts
+++ b/src/discord/commands/guild/d.voice.ts
@@ -13,6 +13,7 @@ import {
 import { SlashCommand } from '../../@types/commandDef';
 import { embedTemplate } from '../../utils/embedTemplate';
 import commandContext from '../../utils/context';
+import { levelRoles, updateTentStatus } from '../../utils/tents';
 
 const F = f(__filename);
 
@@ -89,20 +90,6 @@ async function tentLevel(
   const level = parseInt(levelNumber, 10);
   let title = '';
   let description = '';
-
-  const levelRoles: { [key: number]: string } = {
-    0: env.ROLE_VIP_0,
-    10: env.ROLE_VIP_10,
-    20: env.ROLE_VIP_20,
-    30: env.ROLE_VIP_30,
-    40: env.ROLE_VIP_40,
-    50: env.ROLE_VIP_50,
-    60: env.ROLE_VIP_60,
-    70: env.ROLE_VIP_70,
-    80: env.ROLE_VIP_80,
-    90: env.ROLE_VIP_90,
-    100: env.ROLE_VIP_100,
-  };
 
   if (level === 0) {
     // Iterate over all the level roles and remove their overwrites
@@ -566,6 +553,11 @@ export const dVoice: SlashCommand = {
 
     if (command === 'ping') {
       embed = await tentPing(voiceChannel, member);
+    }
+
+    // Only these commands change something the status line actually shows.
+    if (['lock', 'level', 'limit'].includes(command)) {
+      updateTentStatus(voiceChannel);
     }
 
     await interaction.editReply({ embeds: [embed] });

--- a/src/discord/discord.ts
+++ b/src/discord/discord.ts
@@ -7,6 +7,7 @@ import {
 } from 'discord-api-types/v10';
 import { registerCommands } from './commands';
 import { registerEvents } from './events';
+import { registerTentStatusSync } from './utils/tents';
 
 const F = f(__filename);
 
@@ -46,6 +47,8 @@ export default async function discordConnect(): Promise<void> {
   });
 
   global.discordClient = discordClient;
+
+  registerTentStatusSync(discordClient);
 
   Promise.all([registerCommands(discordClient), registerEvents(discordClient)])
     .then(() => discordClient.login(env.DISCORD_CLIENT_TOKEN))

--- a/src/discord/events/voiceStateUpdate.ts
+++ b/src/discord/events/voiceStateUpdate.ts
@@ -3,7 +3,9 @@ import {
   VoiceState,
 } from 'discord.js';
 import { VoiceStateUpdateEvent } from '../@types/eventDef';
-import { pitchTent, teardownTent, logTent } from '../utils/tents';
+import {
+  pitchTent, teardownTent, logTent, updateTentStatus,
+} from '../utils/tents';
 
 const F = f(__filename); // eslint-disable-line
 
@@ -37,6 +39,9 @@ export const voiceStateUpdate: VoiceStateUpdateEvent = {
     // Check if the user actually left or joined a channel before logging
     if (New.channel !== Old.channel) {
       await logTent(Old, New);
+      // Someone came or went, so refresh the headcount on both tents involved.
+      if (Old.channel) updateTentStatus(Old.channel);
+      if (New.channel) updateTentStatus(New.channel);
     }
 
     await teardownTent(Old);

--- a/src/discord/utils/application.ts
+++ b/src/discord/utils/application.ts
@@ -312,7 +312,24 @@ export async function applicationStart(
     return;
   }
 
-  const channelApplications = await interaction.guild.channels.fetch(channelApplicationsId) as TextChannel;
+  const channelApplications = await interaction.guild.channels
+    .fetch(channelApplicationsId)
+    .catch(() => null) as TextChannel | null;
+
+  if (!channelApplications) {
+    // The stored channel is gone, so the saved id is dead. Clear it so an admin
+    // can re-run setup, and tell the member instead of throwing Unknown Channel.
+    log.error(F, `Applications channel ${channelApplicationsId} no longer exists in ${interaction.guild.name} (set up by ${interaction.user.username}); clearing it.`);
+    await db.discord_guilds.update({
+      where: { id: interaction.guild.id },
+      data: { channel_applications: null },
+    });
+    await interaction.reply({
+      content: 'The applications channel no longer exists — please ask an admin to run the setup again.',
+      flags: MessageFlags.Ephemeral,
+    });
+    return;
+  }
 
   if (!await applicationPermissions(
     interaction,

--- a/src/discord/utils/tents.ts
+++ b/src/discord/utils/tents.ts
@@ -69,7 +69,7 @@ const memberStatus: { [channelId: string]: string } = {};
 // echo so it isn't mistaken for a member edit (which would loop forever).
 const lastWritten: { [channelId: string]: string } = {};
 
-// Separator between the bot-owned status segments (lock / level / capacity).
+// Separator between the bot-owned status segments (lock / level).
 const STATUS_SEP = ' · ';
 
 // Separator between our icons and the member's free-text status. The pipe makes
@@ -78,11 +78,11 @@ const MEMBER_SEP = ' | ';
 
 // The glyphs our segments start with. Only used as a fallback for telling our
 // text apart from the member's when the pipe separator has gone missing.
-const TENT_ICONS = ['🔒', '🎖️', '🪑'];
+const TENT_ICONS = ['🔒', '🎖️'];
 
 /**
- * Build the icon part of a tent's status from its live state: lock, level, and
- * headcount. Each piece is dropped when it doesn't apply, then dot-separated.
+ * Build the icon part of a tent's status from its live state: lock and level.
+ * Each piece is dropped when it doesn't apply, then dot-separated.
  * @param {VoiceBasedChannel} channel The tent channel
  * @return {string} The status line
  */
@@ -98,10 +98,6 @@ export function getTentStatusLine(channel: VoiceBasedChannel): string {
   if (level > 0) {
     segments.push(`🎖️ ${level}+`);
   }
-
-  // Capacity — "full" is conveyed by the numbers (e.g. 8/8); no limit shows count only
-  const humans = channel.members.filter(member => !member.user.bot).size;
-  segments.push(channel.userLimit > 0 ? `🪑 ${humans}/${channel.userLimit}` : `🪑 ${humans}`);
 
   return segments.join(STATUS_SEP);
 }

--- a/src/discord/utils/tents.ts
+++ b/src/discord/utils/tents.ts
@@ -1,4 +1,5 @@
 import {
+  Client,
   Colors,
   VoiceState,
   VoiceBasedChannel,
@@ -17,6 +18,177 @@ import {
 } from 'discord.js';
 
 const F = f(__filename); // eslint-disable-line
+
+// Shared mapping of level requirement -> VIP role id. Used by both the /tent level
+// command and the status line, so the threshold logic lives in one place.
+export const levelRoles: { [level: number]: string } = {
+  0: env.ROLE_VIP_0,
+  10: env.ROLE_VIP_10,
+  20: env.ROLE_VIP_20,
+  30: env.ROLE_VIP_30,
+  40: env.ROLE_VIP_40,
+  50: env.ROLE_VIP_50,
+  60: env.ROLE_VIP_60,
+  70: env.ROLE_VIP_70,
+  80: env.ROLE_VIP_80,
+  90: env.ROLE_VIP_90,
+  100: env.ROLE_VIP_100,
+};
+
+/**
+ * Derive a tent's current level requirement from its permission overwrites.
+ * `/tent level N` denies every VIP role *below* N, so the requirement is the
+ * highest denied level + 10. Returns 0 when there is no requirement.
+ * @param {VoiceBasedChannel} channel The tent channel
+ * @return {number} The level requirement (0 = none)
+ */
+export function getTentLevel(channel: VoiceBasedChannel): number {
+  let highestDenied = -1;
+  Object.entries(levelRoles).forEach(([key, roleId]) => {
+    const level = parseInt(key, 10);
+    const overwrite = channel.permissionOverwrites.cache.get(roleId);
+    if (overwrite && overwrite.deny.has(PermissionsBitField.Flags.ViewChannel) && level > highestDenied) {
+      highestDenied = level;
+    }
+  });
+  return highestDenied < 0 ? 0 : highestDenied + 10;
+}
+
+// Store timeouts for each channel to handle host rejoining
+const hostTimeouts: { [channelId: string]: NodeJS.Timeout } = {};
+
+// Debounce timers for voice-status updates, to coalesce rapid join/leave bursts
+const statusTimeouts: { [channelId: string]: NodeJS.Timeout } = {};
+
+// The member-typed portion of each tent's voice status, kept so the bot can
+// decorate it with state icons instead of clobbering it. Keyed by channel id.
+const memberStatus: { [channelId: string]: string } = {};
+
+// The exact status string the bot last wrote per channel. Our own PUT triggers a
+// VOICE_CHANNEL_STATUS_UPDATE dispatch; this lets the raw listener ignore that
+// echo so it isn't mistaken for a member edit (which would loop forever).
+const lastWritten: { [channelId: string]: string } = {};
+
+// Separator between the bot-owned status segments (lock / level / capacity).
+const STATUS_SEP = ' · ';
+
+// Separator between our icons and the member's free-text status. The pipe makes
+// the member's portion easy to recover on edits and visually distinct.
+const MEMBER_SEP = ' | ';
+
+// The glyphs our segments start with. Only used as a fallback for telling our
+// text apart from the member's when the pipe separator has gone missing.
+const TENT_ICONS = ['🔒', '🎖️', '🪑'];
+
+/**
+ * Build the icon part of a tent's status from its live state: lock, level, and
+ * headcount. Each piece is dropped when it doesn't apply, then dot-separated.
+ * @param {VoiceBasedChannel} channel The tent channel
+ * @return {string} The status line
+ */
+export function getTentStatusLine(channel: VoiceBasedChannel): string {
+  const segments: string[] = [];
+
+  // Lock — show 🔒 only when locked; an open tent is the default and needs no marker
+  const open = channel.permissionsFor(channel.guild.roles.everyone).has(PermissionsBitField.Flags.Connect);
+  if (!open) segments.push('🔒');
+
+  // Level requirement
+  const level = getTentLevel(channel);
+  if (level > 0) {
+    segments.push(`🎖️ ${level}+`);
+  }
+
+  // Capacity — "full" is conveyed by the numbers (e.g. 8/8); no limit shows count only
+  const humans = channel.members.filter(member => !member.user.bot).size;
+  segments.push(channel.userLimit > 0 ? `🪑 ${humans}/${channel.userLimit}` : `🪑 ${humans}`);
+
+  return segments.join(STATUS_SEP);
+}
+
+/**
+ * Combine the bot's state icons with whatever status the member set, so the
+ * member's text is preserved rather than overwritten. Either part may be empty.
+ * @param {VoiceBasedChannel} channel The tent channel
+ * @return {string} The combined status string to write
+ */
+function composeTentStatus(channel: VoiceBasedChannel): string {
+  const icons = getTentStatusLine(channel);
+  const member = memberStatus[channel.id] ?? '';
+  return [icons, member].filter(Boolean).join(MEMBER_SEP);
+}
+
+/**
+ * Recover the member-typed portion of a status. We write `icons | member`, so the
+ * member's text is everything after the first pipe separator. As a fallback (member
+ * cleared our prefix, or Discord normalised the separator), drop any leading
+ * dot-separated segments that start with one of our glyphs.
+ * @param {string} full The full status string as set on the channel
+ * @return {string} The member's portion, with our icons removed
+ */
+function extractMemberText(full: string): string {
+  const pipe = full.indexOf(MEMBER_SEP);
+  if (pipe !== -1) return full.slice(pipe + MEMBER_SEP.length).trim();
+
+  const isOurs = (segment: string): boolean => TENT_ICONS.some(icon => segment.trim().startsWith(icon));
+  const segments = full.split(STATUS_SEP);
+  let i = 0;
+  while (i < segments.length && isOurs(segments[i])) {
+    i += 1;
+  }
+  return segments.slice(i).join(STATUS_SEP).trim();
+}
+
+/**
+ * Push the current state to the tent's Discord voice-status line (the text shown
+ * under the channel name). Debounced (~2.5s) to stay within the endpoint's rate
+ * limit. discord.js 14 has no helper for this, so we call the raw REST route.
+ * @param {VoiceBasedChannel} channel The tent channel
+ * @return {void}
+ */
+export function updateTentStatus(channel: VoiceBasedChannel): void {
+  if (!channel?.name.includes('⛺')) return; // tents only
+  if (statusTimeouts[channel.id]) clearTimeout(statusTimeouts[channel.id]);
+  statusTimeouts[channel.id] = setTimeout(async () => {
+    delete statusTimeouts[channel.id];
+    try {
+      const status = composeTentStatus(channel);
+      // Record before the PUT so the dispatch our own write triggers is ignored.
+      lastWritten[channel.id] = status;
+      await channel.client.rest.put(`/channels/${channel.id}/voice-status`, { body: { status } });
+    } catch (err) {
+      log.error(F, `Failed to set tent status: ${err}`);
+    }
+  }, 2500);
+}
+
+/**
+ * Listen for members setting a tent's voice status and re-apply it with the
+ * bot's state icons attached, so the two coexist in the single status field.
+ *
+ * discord.js forwards every gateway dispatch as the 'raw' event, but it isn't in
+ * the typed ClientEvents and VOICE_CHANNEL_STATUS_UPDATE isn't modelled in this
+ * discord-api-types version — hence the narrow cast and hand-written payload type.
+ * @param {Client} client The Discord client
+ * @return {void}
+ */
+export function registerTentStatusSync(client: Client): void {
+  type RawStatusPacket = { t?: string; d?: { id?: string; status?: string | null } };
+  (client as unknown as {
+    on(event: 'raw', listener: (packet: RawStatusPacket) => void): void;
+  }).on('raw', packet => {
+    if (packet.t !== 'VOICE_CHANNEL_STATUS_UPDATE' || !packet.d?.id) return;
+    const channel = client.channels.cache.get(packet.d.id);
+    if (!channel?.isVoiceBased() || !channel.name.includes('⛺')) return;
+
+    const incoming = packet.d.status ?? '';
+    // Ignore the echo of our own write; only react to genuine member edits.
+    if (incoming === (lastWritten[channel.id] ?? '')) return;
+
+    memberStatus[channel.id] = extractMemberText(incoming);
+    updateTentStatus(channel);
+  });
+}
 
 /**
  * Template
@@ -46,6 +218,7 @@ export async function pitchTent(
     }
   }
 
+  log.debug(F, `pitchTent: creating tent for ${New.member?.displayName} under category ${env.CATEGORY_VOICE}`);
   New.member?.guild.channels.create({
     name: `⛺│${New.member.displayName}'s tent`,
     type: ChannelType.GuildVoice,
@@ -138,11 +311,11 @@ export async function pitchTent(
       ],
       flags: MessageFlags.IsComponentsV2,
     });
+    updateTentStatus(newChannel);
+  }).catch(err => {
+    log.error(F, `pitchTent: failed to create tent (category ${env.CATEGORY_VOICE}): ${err}`);
   });
 }
-
-// Store timeouts for each channel to handle host rejoining
-const hostTimeouts: { [channelId: string]: NodeJS.Timeout } = {};
 
 /**
  * Template
@@ -165,6 +338,16 @@ export async function teardownTent(
         clearTimeout(hostTimeouts[channel.id]);
         delete hostTimeouts[channel.id];
       }
+
+      // Clear any pending status-update timeout for this channel
+      if (statusTimeouts[channel.id]) {
+        clearTimeout(statusTimeouts[channel.id]);
+        delete statusTimeouts[channel.id];
+      }
+
+      // Drop the cached status state for this (now gone) tent
+      delete memberStatus[channel.id];
+      delete lastWritten[channel.id];
 
       try {
         await Old.guild.channels.fetch(channel.id);
@@ -215,6 +398,13 @@ export async function transferTent(
     // Rename the channel
     channel.setName(`⛺│${newHost.displayName}'s tent`);
   }
+
+  // The transfer has fired, so clear the (now stale) pending-transfer marker and
+  // refresh the status so it shows the new host instead of ⏳.
+  if (hostTimeouts[channel.id]) {
+    delete hostTimeouts[channel.id];
+  }
+  updateTentStatus(channel);
 }
 
 const joinMessages = [


### PR DESCRIPTION
<img width="364" height="136" alt="tent" src="https://github.com/user-attachments/assets/b2e29e10-f3b8-41c6-80db-7b000a1d7d1e" />

Tents now show their state in the voice status line - locked or not, any level requirement, and a live headcount:

  ▎ 🔒 · 🎖️ 20+ · 🪑 3/8 | Yeeeeeeeeeee boi

This is all new. One big problem was members already use that status field for their own text, and there's only one of it. So the bot watches for status edits and glues the two together: our icons first, the member's text after the pipe. The lock only shows when a tent is actually locked (open is the default, no need for an icon).

Also in here: fix for an Unknown Channel crash in applications. If the saved applications channel got deleted, /apply threw DiscordAPIError[10003]. Now we clear the dead id so an admin can re-run setup, and tell the member instead of crashing.