### PR TITLE
Remove BuildKit cache mounts from Dockerfile.tripbot

### DIFF
--- a/src/docker/Dockerfile.tripbot
+++ b/src/docker/Dockerfile.tripbot
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends tmux && rm -rf 
 WORKDIR /workspaces/tripbot
 COPY .devcontainer/.tmux.conf /root/.tmux.conf
 COPY package*.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --silent
+RUN npm ci --no-audit --silent
 COPY . .
 RUN npx prisma generate --schema=./src/prisma/tripbot/schema.prisma
 RUN npx prisma generate --schema=./src/prisma/moodle/schema.prisma
@@ -34,7 +34,7 @@ RUN npx tsc --project tsconfig.prisma.json
 RUN rm -f ./build/prisma.config.js ./build/prisma.config.js.map
 
 # 4. PRUNE: Remove devDependencies (this deletes the clients we just made)
-RUN --mount=type=cache,target=/root/.npm rm -rf node_modules && npm ci --omit=dev --no-audit --silent --ignore-scripts
+RUN rm -rf node_modules && npm ci --omit=dev --no-audit --silent --ignore-scripts
 
 # 5. GENERATE FOR RUNTIME: Re-inject the clients into the clean node_modules
 RUN npx prisma generate --schema=./src/prisma/tripbot/schema.prisma
@@ -62,6 +62,6 @@ COPY ./src/docker/entrypoint.sh /workspaces/tripbot/entrypoint.sh
 RUN chmod +x /workspaces/tripbot/entrypoint.sh
 
 # Install PM2 in the final image since your entrypoint uses it
-RUN --mount=type=cache,target=/root/.npm npm install -g pm2
+RUN npm install -g pm2
 
 ENTRYPOINT ["/workspaces/tripbot/entrypoint.sh"]

--- a/src/docker/entrypoint.sh
+++ b/src/docker/entrypoint.sh
@@ -4,6 +4,10 @@ set -e
 if [ "$NODE_ENV" = "development" ]; then
   echo "Waiting for DB..."
   ./src/docker/wait-for-it.sh --timeout=5 tripbot_database:5432
+  if [ ! -d node_modules/prisma ]; then
+    echo "node_modules missing or incomplete (fresh volume?) - running npm ci..."
+    npm ci --no-audit --silent
+  fi
   npm run db:deploy
   npm run db:generate
   # tsc does not emit the (non-TS) generated Prisma client into build/, so copy it


### PR DESCRIPTION
## Summary
- **Build failure on main**: `the --mount option requires BuildKit` — the deploy build environment doesn't have BuildKit enabled. Removes the three `RUN --mount=type=cache,target=/root/.npm ...` cache mounts added in 618314ff, reverting those `RUN` steps to plain `npm ci`/`npm install`.
- **Devcontainer crash loop**: `node_modules` is an anonymous Docker volume that starts empty on a freshly rebuilt container. `entrypoint.sh` ran `npm run db:deploy` immediately on start, racing ahead of VS Code's `postCreateCommand: npm ci`. With `node_modules` empty, `prisma.config.ts`'s `import ... from 'prisma/config'` failed with `Cannot find module 'prisma/config'`, `set -e` killed the container, `restart: unless-stopped` restarted it, and the loop kept interrupting `npm ci` before it could ever finish - an unrecoverable crash loop on any fresh volume. Fixed by having `entrypoint.sh` run `npm ci` itself when `node_modules/prisma` is missing.

## Test plan
- [x] Confirmed locally: removed the `tripbot` container and its anonymous volumes to reproduce a genuinely fresh devcontainer state, then `docker compose up -d tripbot` - container ran `npm ci`, `db:deploy`, `db:generate` for both schemas, and settled into a stable `Up` state with no restart loop.
- [ ] Confirm the main-branch Docker build pipeline succeeds after merge
- [ ] Consider re-adding BuildKit cache mounts later if/when the deploy environment gets BuildKit enabled