### PR TITLE
Re-fix Dockerfile BuildKit mounts + add Docker build CI checks

### DIFF
--- a/.github/workflows/PullRequestOpenAll.yml
+++ b/.github/workflows/PullRequestOpenAll.yml
@@ -76,6 +76,21 @@ jobs:
         run: cp .env.example .env
       - name: Test
         run: npx jest --silent -c ./src/jest/jest.config.ts
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build tripbot image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/docker/Dockerfile.tripbot
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest

--- a/.github/workflows/PushToUat.yml
+++ b/.github/workflows/PushToUat.yml
@@ -70,6 +70,21 @@ jobs:
         run: cp .env.example .env
       - name: Test
         run: npx jest --silent -c ./src/jest/jest.config.ts
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build tripbot image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/docker/Dockerfile.tripbot
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest

--- a/src/docker/Dockerfile.tripbot
+++ b/src/docker/Dockerfile.tripbot
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends tmux && rm -rf 
 WORKDIR /workspaces/tripbot
 COPY .devcontainer/.tmux.conf /root/.tmux.conf
 COPY package*.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --silent
+RUN npm ci --no-audit --silent
 COPY . .
 RUN npx prisma generate --schema=./src/prisma/tripbot/schema.prisma
 RUN npx prisma generate --schema=./src/prisma/moodle/schema.prisma
@@ -34,7 +34,7 @@ RUN npx tsc --project tsconfig.prisma.json
 RUN rm -f ./build/prisma.config.js ./build/prisma.config.js.map
 
 # 4. PRUNE: Remove devDependencies (this deletes the clients we just made)
-RUN --mount=type=cache,target=/root/.npm rm -rf node_modules && npm ci --omit=dev --no-audit --silent --ignore-scripts
+RUN rm -rf node_modules && npm ci --omit=dev --no-audit --silent --ignore-scripts
 
 # 5. GENERATE FOR RUNTIME: Re-inject the clients into the clean node_modules
 RUN npx prisma generate --schema=./src/prisma/tripbot/schema.prisma
@@ -62,6 +62,6 @@ COPY ./src/docker/entrypoint.sh /workspaces/tripbot/entrypoint.sh
 RUN chmod +x /workspaces/tripbot/entrypoint.sh
 
 # Install PM2 in the final image since your entrypoint uses it
-RUN --mount=type=cache,target=/root/.npm npm install -g pm2
+RUN npm install -g pm2
 
 ENTRYPOINT ["/workspaces/tripbot/entrypoint.sh"]


### PR DESCRIPTION
## Summary
PR #1195 got squash-merged before the last two commits landed, and a subsequent "Merge branch 'main' into uat" reverted the Dockerfile fix (main never got it). This PR re-applies everything cleanly on top of current `uat`:

- **Dockerfile fix**: removes the three `RUN --mount=type=cache,target=/root/.npm ...` cache mounts from `Dockerfile.tripbot` — these require BuildKit, which the deploy build environment doesn't have, and were breaking the main build.
- **Devcontainer crash-loop fix**: already merged and present on `uat` (`entrypoint.sh` now runs `npm ci` itself if `node_modules/prisma` is missing) — included here for completeness, no changes needed.
- **CI**: adds a `docker-build` job (via `docker/build-push-action`, no push) to both `PushToUat.yml` and `PullRequestOpenAll.yml` so a broken `Dockerfile.tripbot` build fails CI instead of only surfacing in the external deploy pipeline.

## Test plan
- [x] Cherry-picked cleanly onto current `uat` HEAD, verified `git grep` confirms no `--mount=type=cache` remains and both workflows contain the new `docker-build` job
- [ ] Confirm the new `docker-build` CI check passes on this PR
- [ ] Confirm the main-branch/deploy build pipeline succeeds after merge

## Note
`main` still has the original broken Dockerfile and no CI check — worth doing a follow-up to bring `main` up to date too, otherwise the next `main` → `uat` sync merge could revert this fix again.