### PR TITLE
Remove BuildKit cache mounts from Dockerfile.tripbot + add Docker build CI checks

### DIFF
--- a/.github/workflows/PullRequestOpenAll.yml
+++ b/.github/workflows/PullRequestOpenAll.yml
@@ -76,6 +76,21 @@ jobs:
         run: cp .env.example .env
       - name: Test
         run: npx jest --silent -c ./src/jest/jest.config.ts
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build tripbot image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/docker/Dockerfile.tripbot
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   codeql:
     name: CodeQL
     runs-on: ubuntu-latest

--- a/.github/workflows/PushToMain.yml
+++ b/.github/workflows/PushToMain.yml
@@ -14,6 +14,21 @@ on:
       - '**/build/**'
       - '**/@prisma-moodle/**'
 jobs:
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build tripbot image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/docker/Dockerfile.tripbot
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   # test:
   #   name: Test
   #   runs-on: ubuntu-latest

--- a/src/docker/Dockerfile.tripbot
+++ b/src/docker/Dockerfile.tripbot
@@ -8,7 +8,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends tmux && rm -rf 
 WORKDIR /workspaces/tripbot
 COPY .devcontainer/.tmux.conf /root/.tmux.conf
 COPY package*.json ./
-RUN --mount=type=cache,target=/root/.npm npm ci --no-audit --silent
+RUN npm ci --no-audit --silent
 COPY . .
 RUN npx prisma generate --schema=./src/prisma/tripbot/schema.prisma
 RUN npx prisma generate --schema=./src/prisma/moodle/schema.prisma
@@ -34,7 +34,7 @@ RUN npx tsc --project tsconfig.prisma.json
 RUN rm -f ./build/prisma.config.js ./build/prisma.config.js.map
 
 # 4. PRUNE: Remove devDependencies (this deletes the clients we just made)
-RUN --mount=type=cache,target=/root/.npm rm -rf node_modules && npm ci --omit=dev --no-audit --silent --ignore-scripts
+RUN rm -rf node_modules && npm ci --omit=dev --no-audit --silent --ignore-scripts
 
 # 5. GENERATE FOR RUNTIME: Re-inject the clients into the clean node_modules
 RUN npx prisma generate --schema=./src/prisma/tripbot/schema.prisma
@@ -62,6 +62,6 @@ COPY ./src/docker/entrypoint.sh /workspaces/tripbot/entrypoint.sh
 RUN chmod +x /workspaces/tripbot/entrypoint.sh
 
 # Install PM2 in the final image since your entrypoint uses it
-RUN --mount=type=cache,target=/root/.npm npm install -g pm2
+RUN npm install -g pm2
 
 ENTRYPOINT ["/workspaces/tripbot/entrypoint.sh"]


### PR DESCRIPTION
## Summary
The UAT deploy pipeline builds directly from `https://github.com/tripsit/tripbot.git#main` (see `docker-compose.host.yml` on the deploy host) - not `uat`. Our earlier fixes (#1195, #1197) only ever landed on `uat`, so `main` still had the original broken Dockerfile and the deploy was still failing with `the --mount option requires BuildKit`.

This brings `main` in line with `uat`:
- Removes the three `RUN --mount=type=cache,target=/root/.npm ...` cache mounts from `Dockerfile.tripbot`.
- Adds a `docker-build` job (via `docker/build-push-action`, no push) to `PushToMain.yml` - this is the workflow that runs on every push to `main` and never invoked `docker build` at all, which is exactly why this broke silently.
- Adds the same `docker-build` job to `PullRequestOpenAll.yml` so it's also covered on PRs (main's copy didn't have it yet even though uat's did).

`entrypoint.sh` already has the devcontainer crash-loop fix on `main` from an earlier sync - no changes needed there.

## Test plan
- [x] Cherry-picked cleanly onto current `main` HEAD, verified via `grep` that no `--mount=type=cache` remains and both workflows contain the new `docker-build` job
- [ ] Confirm the new `docker-build` CI check passes on this PR
- [ ] Confirm the external UAT/production deploy pipeline succeeds after merge