### PR TITLE
Add Docker build check to PushToMain workflow

### DIFF
--- a/.github/workflows/PushToMain.yml
+++ b/.github/workflows/PushToMain.yml
@@ -14,6 +14,21 @@ on:
       - '**/build/**'
       - '**/@prisma-moodle/**'
 jobs:
+  docker-build:
+    name: Docker Build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build tripbot image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./src/docker/Dockerfile.tripbot
+          push: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
   # test:
   #   name: Test
   #   runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
`uat`'s Dockerfile/entrypoint.sh fixes and `PushToUat.yml`/`PullRequestOpenAll.yml` docker-build checks are already in place (#1195, #1197). This adds the same `docker-build` job to `PushToMain.yml` so it's ready once `uat` gets promoted to `main` - `PushToMain.yml` only triggers on pushes to `main`, but keeping it in sync on `uat` now means the promotion PR won't need a separate follow-up.

## Why this matters
The external UAT/production deploy pipeline builds from `main` (`docker-compose.host.yml`'s `context: https://github.com/tripsit/tripbot.git#main`), and `main` still has the original broken Dockerfile since none of the earlier fixes reached it yet. `GuardMainSource.yml` requires PRs into `main` to come from the `uat` branch itself, so getting this fully deployed requires: this PR into `uat`, then a `uat` -> `main` promotion PR.

## Test plan
- [x] Verified via `grep`: no `--mount=type=cache` in Dockerfile.tripbot, `docker-build` job present in PushToMain.yml/PushToUat.yml/PullRequestOpenAll.yml, entrypoint.sh has the node_modules guard
- [ ] Confirm the new `docker-build` CI check passes on this PR