### PR TITLE
Added level calculator link to /levels result

### DIFF
--- a/src/discord/commands/guild/d.levels.ts
+++ b/src/discord/commands/guild/d.levels.ts
@@ -1,29 +1,34 @@
+import { personas } from '@db/tripbot';
+import Canvas from '@napi-rs/canvas';
 import {
-  SlashCommandBuilder,
+  ActionRowBuilder,
+  AttachmentBuilder,
+  ButtonBuilder,
+  ButtonStyle,
   ChatInputCommandInteraction,
   // UserContextMenuCommandInteraction,
   GuildMember,
-  AttachmentBuilder,
   MessageFlags,
+  SlashCommandBuilder,
 } from 'discord.js';
-import Canvas from '@napi-rs/canvas';
-import { personas } from '@db/tripbot';
-import { SlashCommand } from '../../@types/commandDef';
 import { levels } from '../../../global/commands/g.levels';
 import { profile, ProfileData } from '../../../global/commands/g.profile';
 import { getPersonaInfo } from '../../../global/commands/g.rpg';
-import getAsset from '../../utils/getAsset';
+import { SlashCommand } from '../../@types/commandDef';
 import commandContext from '../../utils/context';
+import getAsset from '../../utils/getAsset';
 import { numFormatter, numFormatterVoice } from './d.profile';
 
 // import { getTotalLevel } from '../../../global/utils/experience';
-import { resizeText, deFuckifyText, generateColors } from '../../utils/canvasUtils';
+import { deFuckifyText, generateColors, resizeText } from '../../utils/canvasUtils';
 // import { expForNextLevel, getTotalLevel } from '../../../global/utils/experience';
 // import { imageGet } from '../../utils/imageGet';
 
 const F = f(__filename);
 
 const fontSizeFamily = '25px futura';
+
+const levelCalculatorUrl = 'https://tripsit-levelling-calculator.netlify.app/';
 
 type LevelData = {
   ALL: {
@@ -729,7 +734,18 @@ export const dLevels: SlashCommand = {
     const attachment = new AttachmentBuilder(await canvasObj.encode('png'), {
       name: `TS_Levels_${filteredDisplayName}_${formattedDate}.png`,
     });
-    await interaction.editReply({ files: [attachment] });
+    await interaction.editReply({
+      files: [attachment],
+      components: [
+        new ActionRowBuilder<ButtonBuilder>().addComponents([
+          new ButtonBuilder()
+            .setLabel('Level Calculator')
+            .setEmoji('🧮')
+            .setStyle(ButtonStyle.Link)
+            .setURL(levelCalculatorUrl),
+        ]),
+      ],
+    });
 
     log.info(F, `Total Time: ${Date.now() - startTime}ms`);
     return true;

--- a/src/global/commands/g.levels.ts
+++ b/src/global/commands/g.levels.ts
@@ -100,6 +100,8 @@ export async function levels(
     },
   } as LevelData;
 
+  const participatingKeys = new Set<string>();
+
   for (const type of Object.keys(leaderboardData)) { // eslint-disable-line no-restricted-syntax
     const typeKey = type as keyof typeof leaderboardData;
     const typeData = leaderboardData[typeKey];
@@ -124,24 +126,29 @@ export async function levels(
         total_exp: userExperience.total_points,
         rank: userRank + 1, // 0-based to 1-based
       };
+      participatingKeys.add(`${typeKey}.${categoryKey}`);
     }
   }
 
-  // If this user's level is frozen, pin EVERY category's displayed level to the frozen value,
-  // including categories they have no XP in (which the loop above skips). Ranks are left as-is.
+  // If this user's level is frozen, pin the displayed level of the categories they appear in, plus
+  // the headline totals. Categories they have no XP in are left alone. Ranks are left as-is.
   if (frozenLevel !== null) {
     const frozenNextLevel = await expForNextLevel(frozenLevel);
+    const alwaysFrozenKeys = ['ALL.TOTAL', 'TEXT.TOTAL'];
     for (const type of Object.keys(leaderboardData)) {
       const typeKey = type as keyof typeof leaderboardData;
       for (const category of Object.keys(leaderboardData[typeKey])) {
-        const existing = results[typeKey][category];
-        results[typeKey][category] = {
-          level: frozenLevel,
-          level_exp: frozenNextLevel,
-          nextLevel: frozenNextLevel,
-          total_exp: existing ? existing.total_exp : 0,
-          rank: existing ? existing.rank : 0,
-        };
+        const key = `${typeKey}.${category}`;
+        if (participatingKeys.has(key) || alwaysFrozenKeys.includes(key)) {
+          const existing = results[typeKey][category];
+          results[typeKey][category] = {
+            level: frozenLevel,
+            level_exp: frozenNextLevel,
+            nextLevel: frozenNextLevel,
+            total_exp: existing ? existing.total_exp : 0,
+            rank: existing ? existing.rank : 0,
+          };
+        }
       }
     }
   }


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? Link related issues with "Closes #123" if applicable. -->

## Type of change

- [yes I snuck one in which involved showing irrelevant level categories when level freeze is on ] Bug fix
- [yes but it's tiny] New feature
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Other (describe above)

## Checklist

- [ y] Branch is up to date with `uat` (this PR targets `uat`, not `main`)
- [y ] Lint passes for changed files (`npx eslint --ext .ts,.js path/to/file.ts`)
- [y ] Type-check passes (`npx tsc --noEmit --pretty false`)
- [ y] Relevant tests pass (`npm run tripbot:test -- --runInBand`)
- [y ] No secrets, `.env` values, database dumps, or user data included
- [ no changes] Discord command definitions changed? Note that deployment must be requested separately (not done in this PR)

## Test plan

<!-- How did you verify this change? What did you run, and what were the results? -->

Ran /levels in the dev server. Clicked on the link many times. Screenshot below:

<img width="677" height="408" alt="image" src="https://github.com/user-attachments/assets/b7c336a5-64cb-4e05-845e-720e520d1489" />

