### PR TITLE
Reject naughty tent names

### DIFF
--- a/src/discord/commands/guild/d.voice.ts
+++ b/src/discord/commands/guild/d.voice.ts
@@ -2,17 +2,18 @@
 import {
   // Guild,
   Colors,
-  SlashCommandBuilder,
-  GuildMember,
-  PermissionsBitField,
   EmbedBuilder,
-  VoiceBasedChannel,
-  TextChannel,
+  GuildMember,
   MessageFlags,
+  PermissionsBitField,
+  SlashCommandBuilder,
+  TextChannel,
+  VoiceBasedChannel,
 } from 'discord.js';
+import { bigBrother } from '../../../global/utils/thoughtPolice';
 import { SlashCommand } from '../../@types/commandDef';
-import { embedTemplate } from '../../utils/embedTemplate';
 import commandContext from '../../utils/context';
+import { embedTemplate } from '../../utils/embedTemplate';
 import { levelRoles, updateTentStatus } from '../../utils/tents';
 
 const F = f(__filename);
@@ -38,6 +39,16 @@ async function tentName(
   voiceChannel: VoiceBasedChannel,
   newName: string,
 ):Promise<EmbedBuilder> {
+  // Run the new name through the same keyword automod used on chat messages (bigBrother).
+  // If it flags the name, keep the current name and tell the user why.
+  const nameCategory = await bigBrother(newName.toLowerCase());
+  if (['offensive', 'harm', 'horny', 'pg13'].includes(nameCategory)) {
+    return embedTemplate()
+      .setTitle('Tent not renamed')
+      .setColor(Colors.Red)
+      .setDescription('That name contains banned words or phrases, so your tent was not renamed.');
+  }
+
   voiceChannel.setName(`⛺│${newName}`);
 
   // Send the tent update message


### PR DESCRIPTION
## Summary

A few lines of code have been added when a tent is renamed to pass the new name through our current banned words filter. The user is informed if their new tent name was bad.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Other (describe above)

## Checklist

- [x] Branch is up to date with `uat` (this PR targets `uat`, not `main`)
- [x] Lint passes for changed files (`npx eslint --ext .ts,.js path/to/file.ts`)
- [x] Type-check passes (`npx tsc --noEmit --pretty false`)
- [x] Relevant tests pass (`npm run tripbot:test -- --runInBand`)
- [x] No secrets, `.env` values, database dumps, or user data included
- [ ] Discord command definitions changed? Note that deployment must be requested separately (not done in this PR)

## Test plan

I was obnoxiously offensive on the dev server but failed to offend anyone else other than myself.
