### PR TITLE
Auto-sync PR branches with uat, auto-open uat->main promotion PRs

### DIFF
--- a/.github/workflows/PromoteUatToMain.yml
+++ b/.github/workflows/PromoteUatToMain.yml
@@ -1,0 +1,33 @@
+name: PromoteUatToMain
+
+on:
+  push:
+    branches:
+      - uat
+permissions:
+  contents: read
+  pull-requests: write
+jobs:
+  promote:
+    name: Open uat -> main PR if needed
+    runs-on: ubuntu-latest
+    steps:
+      - name: Open a promotion PR when uat is ahead of main
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          existing=$(gh pr list --base main --head uat --state open --json number --jq '.[0].number')
+          if [ -n "$existing" ]; then
+            echo "PR #${existing} is already open from uat to main - it updates itself as uat moves, nothing to do."
+            exit 0
+          fi
+
+          ahead=$(gh api "repos/${GH_REPO}/compare/main...uat" --jq '.ahead_by')
+          if [ "$ahead" -gt 0 ]; then
+            gh pr create --base main --head uat \
+              --title "Promote uat to main" \
+              --body "Automated promotion PR: uat is ${ahead} commit(s) ahead of main."
+          else
+            echo "uat is not ahead of main - nothing to promote."
+          fi

--- a/.github/workflows/SyncPRsWithUat.yml
+++ b/.github/workflows/SyncPRsWithUat.yml
@@ -1,0 +1,24 @@
+name: SyncPRsWithUat
+
+on:
+  push:
+    branches:
+      - uat
+permissions:
+  contents: write
+  pull-requests: write
+jobs:
+  update-behind-prs:
+    name: Update PR branches behind uat
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update every open PR targeting uat
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          for pr in $(gh pr list --base uat --state open --json number --jq '.[].number'); do
+            echo "Updating PR #$pr with latest uat..."
+            gh api -X PUT "repos/${GH_REPO}/pulls/${pr}/update-branch" \
+              || echo "::warning::Could not auto-update PR #${pr} (likely a real conflict or a fork branch) - needs manual update."
+          done


### PR DESCRIPTION
## Summary
- `SyncPRsWithUat.yml`: on every push to `uat`, updates every open PR targeting `uat` that's fallen behind (via GitHub's `update-branch` API), so PR diffs don't get polluted with unrelated commits the way #1211 did.
- `PromoteUatToMain.yml`: on every push to `uat`, opens a `uat -> main` PR automatically if `uat` is ahead of `main` and no such PR is already open, replacing the manual promotion step.

## Test plan
- [x] Both YAML files validated with `python3 -c "import yaml; ..."`
- [ ] Push a commit to `uat` and confirm SyncPRsWithUat updates any open PRs targeting it
- [ ] Confirm PromoteUatToMain opens a PR next time uat gets ahead of main, and doesn't duplicate it on subsequent pushes