### PR TITLE
Fix Claude Code Review skipping bot-opened PRs into uat/main

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,6 +12,12 @@ on:
 
 jobs:
   claude-review:
+    # SyncMainToUat.yml opens a diffless PR (0 changed files) purely to keep uat's git
+    # ancestry current with main; there's nothing to review, so skip it. This also covers
+    # any other empty PR generically, without hardcoding a branch name. The uat->main
+    # promotion PR always has real changes, so it isn't affected by this check.
+    if: github.event.pull_request.changed_files > 0
+
     # Optional: Filter by PR author
     # if: |
     #   github.event.pull_request.user.login == 'external-contributor' ||
@@ -36,6 +42,11 @@ jobs:
         uses: anthropics/claude-code-action@v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          # SyncMainToUat.yml and PromoteUatToMain.yml open their PRs as github-actions[bot];
+          # without this, the action's non-human-actor guard silently skips review on every
+          # automated uat<->main PR. Kept as an explicit name (not '*') per the action's own
+          # security guidance, since '*' would let any GitHub App trigger this action unchecked.
+          allowed_bots: 'github-actions[bot]'
           plugin_marketplaces: 'https://github.com/anthropics/claude-code.git'
           plugins: 'code-review@claude-code-plugins'
           prompt: '/code-review:code-review --comment ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'


### PR DESCRIPTION
## Summary

The `Claude Code Review` workflow was silently failing on every automated PR into `uat`/`main` (opened by `github-actions[bot]` via `SyncMainToUat.yml` / `PromoteUatToMain.yml`), because `anthropics/claude-code-action` refuses to run for non-human actors unless explicitly allow-listed. Confirmed via the failed run's log:

```
##[error]Action failed with error: Workflow initiated by non-human actor: github-actions (type: Bot). Add bot to allowed_bots list or use '*' to allow all bots.
```

This meant the uat -> main promotion PR (which does carry real content) was never actually getting reviewed either — not just the diffless sync PR.

Two changes to `.github/workflows/claude-code-review.yml`:

- Added `allowed_bots: 'github-actions[bot]'` so the action runs on PRs opened by that bot (an explicit name, not `'*'`, per the action's own security guidance — a wildcard would let any GitHub App trigger it unchecked).
- Added `if: github.event.pull_request.changed_files > 0` on the job so the diffless `sync/main-into-uat` PR (0 changed files, opened purely to keep `uat`'s ancestry current with `main`) is skipped generically, without hardcoding a branch name. The uat -> main promotion PR always has real changes, so it's unaffected by this check and still gets reviewed.

## Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor / chore
- [ ] Other (describe above)

## Checklist

- [x] Branch is up to date with `uat` (this PR targets `uat`, not `main`)
- [x] Lint passes for changed files (N/A — YAML only, no lintable app code changed)
- [x] Type-check passes (N/A — YAML only, no lintable app code changed)
- [ ] Relevant tests pass — N/A, no test-covered code changed
- [x] No secrets, `.env` values, database dumps, or user data included
- [ ] Discord command definitions changed? N/A

## Test plan

- Validated the workflow YAML parses correctly (`python3 -c "import yaml; yaml.safe_load(open('.github/workflows/claude-code-review.yml'))"`).
- Confirmed the failure root cause directly from the GitHub Actions job log for the failed run on PR #1217.
- Confirmed via `gh api repos/tripsit/tripbot/pulls/1217` that `changed_files` is `0` for the sync PR and that its author is `github-actions[bot]` (type `Bot`).
- Could not fully simulate the live GitHub Actions trigger locally; recommend watching the next `uat` sync PR and the next `uat -> main` promotion PR to confirm the sync PR is skipped and the promotion PR gets reviewed.