### PR TITLE
Skip command files with no exported SlashCommand instead of crashing

### DIFF
--- a/src/discord/utils/commandDeploy.ts
+++ b/src/discord/utils/commandDeploy.ts
@@ -19,10 +19,25 @@ async function getCommands(commandType: string): Promise<SlashCommand[]> {
   // log.debug(F, `${commandType} command files: ${files}`);
   return files
     .filter(file => (file.endsWith('.ts') || file.endsWith('.js')) && !file.startsWith('index'))
-    .map(file =>
+    .map(file => ({
+      file,
       // log.debug(F, `${commandType} command file: ${file}`);
-       require(`${commandDir}/${commandType}/${file}`)) // eslint-disable-line
-    .map(command => command[Object.keys(command).find(key => command[key].data !== undefined) as string].data.toJSON());
+      command: require(`${commandDir}/${commandType}/${file}`), // eslint-disable-line
+    }))
+    .filter(({ file, command }) => {
+      const key = Object.keys(command).find(k => command[k] && command[k].data !== undefined);
+      // log.warn() unconditionally touches global.rollbar, which isn't set up in this standalone
+      // script's execution path (only during normal bot startup) - console.warn avoids that.
+      if (!key) {
+        // eslint-disable-next-line no-console
+        console.warn(`[commandDeploy] Skipping ${commandType}/${file} - no SlashCommand .data export found.`);
+      }
+      return key !== undefined;
+    })
+    .map(({ command }) => {
+      const key = Object.keys(command).find(k => command[k] && command[k].data !== undefined) as string;
+      return command[key].data.toJSON();
+    });
 }
 
 export default async function deployCommands():Promise<{


### PR DESCRIPTION
## Summary
- `getCommands()` in `commandDeploy.ts` assumed every file in `commands/global` and `commands/guild` exports a `SlashCommand` with a `.data` builder.
- `d.prReview.ts` only exports a button handler and a notify function, so the `.data` lookup came back empty and crashed the whole deploy on `.data` of `undefined` — blocking registration of *every* command, not just that one.
- Now it skips a file with no matching export and logs a warning naming it, instead of crashing.

## Test plan
- [x] Ran `npx tsc --noEmit` — clean
- [x] Ran `npx eslint` on the changed file — clean
- [x] Dry-ran `commandDeploy.ts` with an invalid token — confirmed it skips `d.prReview.ts` with a warning, builds the full command list, and fails only at the (expected) Discord API auth step

🤖 Generated with [Claude Code](https://claude.com/claude-code)