### PR TITLE
Mod thread history and thread enhancements

### DIFF
--- a/src/discord/events/buttonClick.ts
+++ b/src/discord/events/buttonClick.ts
@@ -25,6 +25,7 @@ import {
 } from '../commands/guild/d.rpg';
 import { helperButton } from '../commands/global/d.setup';
 import { acknowledgeButton, modModal, refusalButton } from '../utils/modUtils';
+import { modHistoryButton } from '../utils/modHistory';
 import { feedbackReportModal } from '../commands/global/d.feedback';
 import { aiButton } from '../commands/global/d.ai';
 import { purgeButton } from '../commands/guild/d.purge';
@@ -67,6 +68,11 @@ export async function buttonClick(interaction:ButtonInteraction, discordClient:C
       interaction.update(await mushroomPageEmbed(2));
       return;
     }
+  }
+
+  if (buttonID.startsWith('modHistory')) {
+    await modHistoryButton(interaction);
+    return;
   }
 
   if (buttonID.startsWith('moderate')) {

--- a/src/discord/events/selectMenu.ts
+++ b/src/discord/events/selectMenu.ts
@@ -8,6 +8,7 @@ import commandContext from '../utils/context';
 import { helpMenu } from '../commands/global/d.help';
 import { aiMenu } from '../commands/global/d.ai';
 import { purgeMenu } from '../commands/guild/d.purge';
+import { modHistoryButton } from '../utils/modHistory';
 // import log from '../../global/utils/log';
 // import {parse} from 'path';
 const F = f(__filename);
@@ -23,6 +24,10 @@ export async function selectMenu(
   const menuID = interaction.customId;
 
   if (interaction.isStringSelectMenu()) {
+    if (menuID.startsWith('modHistory')) {
+      await modHistoryButton(interaction);
+      return;
+    }
     if (menuID.startsWith('helpSelectMenu')) {
       await helpMenu(interaction);
       return;

--- a/src/discord/utils/modHistory.ts
+++ b/src/discord/utils/modHistory.ts
@@ -1,0 +1,350 @@
+import { user_action_type, user_actions } from '@db/tripbot';
+import {
+  ActionRowBuilder,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  Colors,
+  EmbedBuilder,
+  Guild,
+  GuildMember,
+  MessageFlags,
+  StringSelectMenuBuilder,
+  StringSelectMenuInteraction,
+  StringSelectMenuOptionBuilder,
+  time,
+} from 'discord.js';
+import { embedTemplate } from './embedTemplate';
+import { tripSitTrustScore } from './trustScore';
+
+const F = f(__filename);
+
+export type ModHistoryInteraction = ButtonInteraction | StringSelectMenuInteraction;
+
+// Only the types that get a count field on the mod embed.
+const historyCategories = [
+  {
+    type: 'NOTE', plural: 'Notes', singular: 'Note', emoji: '🗒️', color: Colors.Yellow,
+  },
+  {
+    type: 'WARNING', plural: 'Warns', singular: 'Warn', emoji: '⚠️', color: Colors.Yellow,
+  },
+  {
+    type: 'REPORT', plural: 'Reports', singular: 'Report', emoji: '📝', color: Colors.Orange,
+  },
+  {
+    type: 'TIMEOUT', plural: 'Timeouts', singular: 'Timeout', emoji: '⏳', color: Colors.Yellow,
+  },
+  {
+    type: 'KICK', plural: 'Kicks', singular: 'Kick', emoji: '👢', color: Colors.Orange,
+  },
+  {
+    type: 'FULL_BAN', plural: 'Bans', singular: 'Ban', emoji: '🔨', color: Colors.Red,
+  },
+  {
+    type: 'UNDERBAN', plural: 'Underbans', singular: 'Underban', emoji: '🔨', color: Colors.Red,
+  },
+] as const;
+
+type HistoryCategory = typeof historyCategories[number];
+
+const profileValue = 'PROFILE';
+
+export type ModActionCounts = Partial<Record<user_action_type, number>>;
+
+export async function modActionCounts(userId: string): Promise<ModActionCounts> {
+  const grouped = await db.user_actions.groupBy({
+    by: ['type'],
+    where: { user_id: userId },
+    _count: { _all: true },
+  });
+
+  const counts = {} as ModActionCounts;
+  grouped.forEach(row => {
+    counts[row.type] = row._count._all; // eslint-disable-line no-underscore-dangle
+  });
+  return counts;
+}
+
+export function modHistoryRows(
+  discordId: string,
+  counts: ModActionCounts,
+): ActionRowBuilder<StringSelectMenuBuilder>[] {
+  const options = [
+    new StringSelectMenuOptionBuilder()
+      .setValue(profileValue)
+      .setLabel('View Profile & TrustScore')
+      .setDescription('Account age, join dates, roles, TrustScore')
+      .setEmoji('ℹ️'),
+    ...historyCategories
+      .filter(category => (counts[category.type] ?? 0) > 0)
+      .map(category => new StringSelectMenuOptionBuilder()
+        .setValue(category.type)
+        .setLabel(`View ${category.plural} (${counts[category.type]})`)
+        .setEmoji(category.emoji)),
+  ];
+
+  return [new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId(`modHistory~select~${discordId}`)
+      .setPlaceholder('View Mod History')
+      .addOptions(options),
+  )];
+}
+
+function navigationRow(
+  category: HistoryCategory,
+  discordId: string,
+  index: number,
+  total: number,
+): ActionRowBuilder<ButtonBuilder> {
+  // Slot suffix stops First/Prev (and Next/Last) colliding on the edge pages.
+  const button = (label: string, emoji: string, target: number, disabled: boolean) => new ButtonBuilder()
+    .setCustomId(`modHistory~page~${category.type}~${discordId}~${target}~${label.toLowerCase()}`)
+    .setLabel(label)
+    .setEmoji(emoji)
+    .setStyle(ButtonStyle.Secondary)
+    .setDisabled(disabled);
+
+  const row = new ActionRowBuilder<ButtonBuilder>();
+  if (total > 2) {
+    row.addComponents(button('First', '⏮️', 0, index === 0));
+  }
+  row.addComponents(
+    button('Prev', '◀️', Math.max(index - 1, 0), index === 0),
+    button('Next', '▶️', Math.min(index + 1, total - 1), index === total - 1),
+  );
+  if (total > 2) {
+    row.addComponents(button('Last', '⏭️', total - 1, index === total - 1));
+  }
+
+  return row;
+}
+
+async function historyPageEmbed(
+  category: HistoryCategory,
+  discordId: string,
+  index: number,
+  total: number,
+  action: user_actions,
+): Promise<EmbedBuilder> {
+  const [creator, repealer] = await Promise.all([
+    db.users.findUnique({ where: { id: action.created_by } }),
+    action.repealed_by
+      ? db.users.findUnique({ where: { id: action.repealed_by } })
+      : Promise.resolve(null),
+  ]);
+
+  const embed = embedTemplate()
+    .setColor(category.color)
+    .setDescription(`**${category.singular} ${index + 1} of ${total}** for <@${discordId}>`)
+    .addFields(
+      {
+        name: 'Moderator',
+        value: creator?.discord_id ? `<@${creator.discord_id}>` : 'Unknown',
+        inline: true,
+      },
+      {
+        name: 'Date',
+        value: `${time(action.created_at, 'f')}\n${time(action.created_at, 'R')}`,
+        inline: true,
+      },
+      { name: 'Reason', value: action.internal_note.slice(0, 1024) || 'No reason provided' },
+      {
+        name: 'Note sent to user',
+        value: action.description ? action.description.slice(0, 1024) : '*No message sent to user*',
+      },
+    )
+    .setFooter({ text: `Page ${index + 1} / ${total}` });
+
+  if (action.expires_at) {
+    embed.addFields({ name: 'Expires', value: time(action.expires_at, 'R'), inline: true });
+  }
+  if (action.repealed_at) {
+    const repealedBy = repealer?.discord_id ? `<@${repealer.discord_id}>` : 'Unknown';
+    embed.addFields({
+      name: 'Repealed',
+      value: `${time(action.repealed_at, 'R')} by ${repealedBy}`,
+      inline: true,
+    });
+  }
+
+  return embed;
+}
+
+async function profileEmbed(guild: Guild, discordId: string): Promise<EmbedBuilder> {
+  const [user, member, userData] = await Promise.all([
+    discordClient.users.fetch(discordId).catch(() => null),
+    guild.members.fetch(discordId).catch(() => null),
+    db.users.findFirst({ where: { discord_id: discordId } }),
+  ]);
+
+  if (!user && !member) {
+    return embedTemplate()
+      .setColor(Colors.DarkOrange)
+      .setDescription(`Could not fetch <@${discordId}>. The account was likely deleted.`);
+  }
+
+  const embed = embedTemplate()
+    .setColor(Colors.Green)
+    .setDescription(`**Profile for <@${discordId}>**`);
+
+  const avatar = member?.displayAvatarURL() ?? user?.displayAvatarURL();
+  if (avatar) {
+    embed.setThumbnail(avatar);
+  }
+
+  embed.addFields(
+    { name: 'Username', value: user?.username ?? 'Unknown', inline: true },
+    { name: 'Display name', value: member?.displayName ?? user?.displayName ?? 'Unknown', inline: true },
+    { name: 'ID', value: discordId, inline: true },
+  );
+
+  if (user) {
+    embed.addFields({
+      name: 'Account created',
+      value: `${time(user.createdAt, 'D')}\n${time(user.createdAt, 'R')}`,
+      inline: true,
+    });
+  }
+  embed.addFields({
+    name: 'Joined server',
+    value: member?.joinedAt
+      ? `${time(member.joinedAt, 'D')}\n${time(member.joinedAt, 'R')}`
+      : 'Not in the server',
+    inline: true,
+  });
+  if (userData) {
+    embed.addFields({
+      name: 'Known to TripBot since',
+      value: `${time(userData.joined_at, 'D')}\n${time(userData.joined_at, 'R')}`,
+      inline: true,
+    });
+    embed.addFields(
+      { name: 'Last seen', value: time(userData.last_seen_at, 'R'), inline: true },
+      {
+        name: 'Karma',
+        value: `${userData.karma_received} received / ${userData.karma_given} given`,
+        inline: true,
+      },
+    );
+  }
+
+  const timeoutEnds = member?.communicationDisabledUntilTimestamp;
+  if (timeoutEnds && timeoutEnds > Date.now()) {
+    embed.addFields({
+      name: 'Currently muted until',
+      value: time(new Date(timeoutEnds), 'R'),
+      inline: true,
+    });
+  }
+
+  const roles = member?.roles.cache
+    .filter(role => role.id !== guild.id)
+    .sort((a, b) => b.position - a.position)
+    .map(role => `<@&${role.id}>`) ?? [];
+  if (roles.length > 0) {
+    embed.addFields({ name: `Roles (${roles.length})`, value: roles.join(' ').slice(0, 1024) });
+  }
+
+  const { trustScore, tsReasoning } = await tripSitTrustScore(discordId);
+  embed.addFields({
+    name: 'TripSit TrustScore',
+    value: `**${trustScore}**\n\`\`\`${tsReasoning.slice(0, 950)}\`\`\``,
+  });
+
+  return embed;
+}
+
+// Dropdown is modHistory~select~<id> with the type in values[0]; buttons are
+// modHistory~page|open~<type>~<id>~<n>. 'open' only exists on already-posted embeds.
+function parseHistoryId(interaction: ModHistoryInteraction): {
+  isPage: boolean;
+  type: string;
+  discordId: string;
+  rawIndex: string;
+} {
+  const parts = interaction.customId.split('~');
+  if (interaction.isStringSelectMenu()) {
+    return {
+      isPage: false, type: interaction.values[0], discordId: parts[2], rawIndex: '0',
+    };
+  }
+  return {
+    isPage: parts[1] === 'page', type: parts[2], discordId: parts[3], rawIndex: parts[4],
+  };
+}
+
+export async function modHistoryButton(interaction: ModHistoryInteraction): Promise<void> {
+  if (!interaction.guild) {
+    return;
+  }
+  const {
+    isPage, type, discordId, rawIndex,
+  } = parseHistoryId(interaction);
+
+  const category = historyCategories.find(c => c.type === type);
+  if (!category && type !== profileValue) {
+    log.error(F, `Unknown mod history category: ${type}`);
+    return;
+  }
+
+  if (isPage) {
+    await interaction.deferUpdate();
+  } else {
+    await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+  }
+
+  const guildData = await db.discord_guilds.upsert({
+    where: { id: interaction.guild.id },
+    create: { id: interaction.guild.id },
+    update: {},
+  });
+
+  const actor = interaction.member as GuildMember | null;
+  if (!guildData.role_moderator || !actor?.roles.cache.has(guildData.role_moderator)) {
+    await interaction.editReply({
+      embeds: [embedTemplate()
+        .setColor(Colors.Red)
+        .setDescription('Only moderators can view mod history.')],
+      components: [],
+    });
+    return;
+  }
+
+  if (!category) {
+    await interaction.editReply({
+      embeds: [await profileEmbed(interaction.guild, discordId)],
+      components: [],
+    });
+    return;
+  }
+
+  const userData = await db.users.findFirst({ where: { discord_id: discordId } });
+  const actions = userData
+    ? await db.user_actions.findMany({
+      where: { user_id: userData.id, type: category.type },
+      orderBy: { created_at: 'asc' },
+    })
+    : [];
+
+  if (actions.length === 0) {
+    await interaction.editReply({
+      embeds: [embedTemplate()
+        .setColor(Colors.DarkOrange)
+        .setDescription(`No ${category.plural.toLowerCase()} found for <@${discordId}>.`)],
+      components: [],
+    });
+    return;
+  }
+
+  const index = Math.min(Math.max(Number.parseInt(rawIndex, 10) || 0, 0), actions.length - 1);
+  await interaction.editReply({
+    embeds: [await historyPageEmbed(category, discordId, index, actions.length, actions[index])],
+    components: actions.length > 1
+      ? [navigationRow(category, discordId, index, actions.length)]
+      : [],
+  });
+}
+
+export default modHistoryButton;

--- a/src/discord/utils/modUtils.ts
+++ b/src/discord/utils/modUtils.ts
@@ -19,7 +19,6 @@ import {
   ButtonInteraction,
   ChatInputCommandInteraction,
   Colors,
-  DiscordAPIError,
   DiscordErrorData,
   EmbedBuilder,
   Guild,
@@ -27,10 +26,11 @@ import {
   GuildMember,
   InteractionEditReplyOptions,
   InteractionReplyOptions,
+  Message,
+  MessageActionRowComponentBuilder,
   MessageContextMenuCommandInteraction,
   ModalBuilder,
   ModalSubmitInteraction,
-  PermissionResolvable,
   Role,
   Snowflake,
   TextChannel,
@@ -44,11 +44,12 @@ import { Duration } from 'luxon';
 import { parseDuration, validateDurationInput } from '../../global/utils/parseDuration';
 import { embedTemplate } from './embedTemplate';
 import { getDiscordMember } from './guildMemberLookup';
+import { modActionCounts, modHistoryRows } from './modHistory';
+import { tripSitTrustScore } from './trustScore';
 
 // import { last } from '../../../global/commands/g.last';
 import { last } from '../../global/commands/g.last';
 import { appealAccept, appealReject } from './appeal';
-import { checkGuildPermissions } from './checkPermissions';
 
 /* TODO:
 add dates to bans
@@ -412,18 +413,10 @@ export const modButtonBan = (discordId: string) => new ButtonBuilder()
   .setEmoji('🔨')
   .setStyle(ButtonStyle.Danger);
 
-// Quick-ban shortcuts: open the normal full-ban modal pre-filled (reason + 7-day purge, no
-// user message). The `~vendor`/`~bot` segment is read in modModal to drive the prefill, and
-// the prefilled reason ('Vendor'/'Bot') triggers the existing isVendorBotBan no-DM behavior.
-export const modButtonBanVendor = (discordId: string) => new ButtonBuilder()
-  .setCustomId(`moderate~FULL_BAN~${discordId}~vendor`)
-  .setLabel('Vendor')
-  .setEmoji('🪧')
-  .setStyle(ButtonStyle.Danger);
-
-export const modButtonBanBot = (discordId: string) => new ButtonBuilder()
-  .setCustomId(`moderate~FULL_BAN~${discordId}~bot`)
-  .setLabel('Bot')
+// The prefilled reason is what triggers isVendorBotBan, so no DM and no mod thread.
+export const modButtonBanVendorBot = (discordId: string) => new ButtonBuilder()
+  .setCustomId(`moderate~FULL_BAN~${discordId}~vendorbot`)
+  .setLabel('Vendor / Bot')
   .setEmoji('🤖')
   .setStyle(ButtonStyle.Danger);
 
@@ -450,197 +443,6 @@ export const modButtonRejectAppeal = (discordId: string) => new ButtonBuilder()
   .setLabel('Deny')
   .setEmoji('❌')
   .setStyle(ButtonStyle.Secondary);
-
-export async function tripSitTrustScore(
-  targetId: string,
-): Promise<{
-    trustScore: number;
-    tsReasoning: string;
-  }> {
-  // const startTime = Date.now();
-  let trustScore = 0;
-  let tsReasoning = '';
-  const targetPromise = discordClient.users.fetch(targetId);
-  const guildsPromise = discordClient.guilds.fetch();
-
-  const target = await targetPromise; // Await here since target is needed for the calculations below
-  // Calculate how like it is that this user is a trust.
-  // This is based off of factors like, how old is their account, do they have a profile picture, etc.
-  const diff = Math.abs(Date.now() - Date.parse(target.createdAt.toString()));
-  const years = Math.floor(diff / (1000 * 60 * 60 * 24 * 365));
-  const months = Math.floor(diff / (1000 * 60 * 60 * 24 * 30));
-  const weeks = Math.floor(diff / (1000 * 60 * 60 * 24 * 7));
-  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
-  const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
-  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
-  const seconds = Math.floor((diff % (1000 * 60)) / 1000);
-  if (years > 0) {
-    trustScore += 6;
-    tsReasoning += '+6 | Account was created at least a year ago\n';
-  } else if (years === 0 && months > 0) {
-    trustScore += 5;
-    tsReasoning += '+5 | Account was created months ago\n';
-  } else if (months === 0 && weeks > 0) {
-    trustScore += 4;
-    tsReasoning += '+4 | Account was created weeks ago\n';
-  } else if (weeks === 0 && days > 0) {
-    trustScore += 3;
-    tsReasoning += '+3 | Account was created days ago\n';
-  } else if (days === 0 && hours > 0) {
-    trustScore += 2;
-    tsReasoning += '+2 | Account was created hours ago\n';
-  } else if (hours === 0 && minutes > 0) {
-    trustScore += 1;
-    tsReasoning += '+1 | Account was created minutes ago\n';
-  } else if (minutes === 0 && seconds > 0) {
-    trustScore += 0;
-    tsReasoning += '+0 | Account was created seconds ago\n';
-  }
-
-  if (target.avatarURL()) {
-    trustScore += 1;
-    tsReasoning += '+1 | Account has a profile picture\n';
-  } else {
-    trustScore += 0;
-    tsReasoning += '+0 | Account does not have a profile picture\n';
-  }
-
-  // if (target.bannerURL() !== null) {
-  //   trustScore += 1;
-  //   tsReasoning += '+1 | Account has a banner\n';
-  // } else {
-  //   trustScore += 0;
-  //   tsReasoning += '+0 | Account does not have a banner\n';
-  // }
-
-  // Check how many guilds the member is in
-  // await discordClient.guilds.fetch();
-  // const targetInGuilds = await Promise.all(discordClient.guilds.cache.map(async guild => {
-  //   try {
-  //     await guild.members.fetch(target.id);
-  //     // log.debug(F, `User is in guild: ${guild.name}`);
-  //     return guild;
-  //   } catch (err: unknown) {
-  //     return null;
-  //   }
-  // }));
-
-  const [, targetInGuilds] = await Promise.all([
-    guildsPromise, // Await the fetched guilds
-    Promise.all(discordClient.guilds.cache.map(async guild => {
-      if (guild.members.cache.get(target.id)) {
-        return guild;
-      }
-      return null;
-    })),
-  ]);
-  const mutualGuilds = targetInGuilds.filter(item => item);
-
-  if (mutualGuilds.length > 0) {
-    trustScore += mutualGuilds.length;
-    tsReasoning += `+${mutualGuilds.length} | I currently share ${mutualGuilds.length} guilds with them\n`;
-  } else {
-    trustScore += 0;
-    tsReasoning += '+0 | Account is only in this guild, that i can tell\n';
-  }
-
-  await discordClient.guilds.fetch();
-  // const noPermissionGuilds = [] as Guild[];
-  const notFoundGuilds = [] as Guild[];
-  const errorGuilds = [] as Guild[];
-  // const bannedTest = await Promise.all(discordClient.guilds.cache.map(async guild => {
-  //   // log.debug(F, `Checking guild: ${guild.name}`);
-  //   const guildPerms = await checkGuildPermissions(guild, [
-  //     'BanMembers' as PermissionResolvable,
-  //   ]);
-
-  //   if (!guildPerms) {
-  //     // log.debug(F, `No permission to check guild: ${guild.name}`);
-  //     noPermissionGuilds.push(guild);
-  //     return null;
-  //   }
-
-  //   try {
-  //     return await guild.bans.fetch(target.id);
-  //     // log.debug(F, `User is banned in guild: ${guild.name}`);
-  //     // return guild.name;
-  //   } catch (err: unknown) {
-  //     if ((err as DiscordAPIError).code === 10026) {
-  //       // log.debug(F, `User is not banned in guild: ${guild.name}`);
-  //       notFoundGuilds.push(guild);
-  //       return null;
-  //     }
-  //     // log.debug(F, `Error checking guild: ${guild.name}`);
-  //     errorGuilds.push(guild);
-  //     return null;
-  //   }
-  // }));
-
-  // Separate promises for checking permissions and bans
-  const permissionsPromises = discordClient.guilds.cache.map(guild => checkGuildPermissions(guild, ['BanMembers' as PermissionResolvable]));
-  const bansPromises = discordClient.guilds.cache.map(async guild => {
-    try {
-      return guild.bans.cache.get(target.id);
-    } catch (err: unknown) {
-      if ((err as DiscordAPIError).code === 10026) {
-        notFoundGuilds.push(guild);
-        return null;
-      }
-      errorGuilds.push(guild);
-      return null;
-    }
-  });
-
-  const [permissionsResults, bannedTest] = await Promise.all([
-    Promise.all(permissionsPromises),
-    Promise.all(bansPromises),
-  ]);
-
-  // count how many 'banned' appear in the array
-  const bannedGuilds = bannedTest.filter(item => item) as GuildBan[];
-  // log.debug(F, `Banned Guilds: ${bannedGuilds.join(', ')}`);
-
-  // log.debug(F, `permissionsResults: ${permissionsResults}`);
-  // log.debug(F, `bannedTest: ${bannedTest}`);
-  const noPermissionGuilds = permissionsResults.filter(item => !item.hasPermission);
-
-  // count how many i didn't have permission to check
-  // log.debug(F, `No Permission Guilds: ${noPermissionGuilds.map(guild => guild.name).join(', ')}`);
-  // log.debug(F, `Not Found Guilds: ${notFoundGuilds.map(guild => guild.name).join(', ')}`);
-  // log.debug(F, `Error Guilds: ${errorGuilds.map(guild => guild.name).join(', ')}`);
-  const checkedGuildNumber = bannedTest.length - noPermissionGuilds.length;
-
-  if (bannedGuilds.length === 0) {
-    trustScore += 0;
-    tsReasoning += stripIndents`+0 | Not banned in ${checkedGuildNumber} other guilds that I can see.`;
-  } else {
-    trustScore -= (bannedGuilds.length * 5);
-    // eslint-disable-next-line max-len
-
-    const tsBanReasons = (await Promise.all(bannedGuilds.map(async banData => {
-      if (banData.partial) {
-        await banData.fetch();
-      }
-
-      let reasonStr = ': No reason found.';
-      if (banData.reason) {
-        reasonStr = `: ${banData.reason}`;
-      }
-
-      return `${banData.guild.name}${reasonStr}`;
-    }))).join('\n');
-
-    tsReasoning += stripIndents`-${(bannedGuilds.length * 5)} | Banned in least ${bannedGuilds.length} of the ${checkedGuildNumber} guilds I can check.
-    ${tsBanReasons}
-    `;
-  }
-
-  // log.debug(F, `[trust score] time: ${Date.now() - startTime}ms`);
-  return {
-    trustScore,
-    tsReasoning,
-  };
-}
 
 export async function userInfoEmbed(
   actor: GuildMember | null,
@@ -670,6 +472,9 @@ export async function userInfoEmbed(
     KICK: [] as string[],
     FULL_BAN: [] as string[],
     UNDERBAN: [] as string[],
+    BAN_EVASION: [] as string[],
+    APPEAL_ACCEPT: [] as string[],
+    APPEAL_REJECT: [] as string[],
     TICKET_BAN: [] as string[],
     DISCORD_BOT_BAN: [] as string[],
     HELPER_BAN: [] as string[],
@@ -766,6 +571,12 @@ export async function userInfoEmbed(
   // );
 
   const description = `Report <@${targetId}>`;
+  let threadLink = '';
+  if (showModInfo && targetData.mod_thread_id) {
+    threadLink = actor?.guild
+      ? `\n[View mod thread](https://discord.com/channels/${actor.guild.id}/${targetData.mod_thread_id})`
+      : `\n<#${targetData.mod_thread_id}>`;
+  }
   if (command === 'REPORT') {
     modlogEmbed.setDescription(`${description}
       
@@ -823,7 +634,7 @@ export async function userInfoEmbed(
     if (targetActionList.UNDERBAN.length > 0) {
       modlogEmbed.addFields({ name: '# of Underbans', value: `${targetActionList.UNDERBAN.length}`, inline: true });
     }
-    modlogEmbed.setDescription(`${description}`);
+    modlogEmbed.setDescription(`${description}${threadLink}`);
     // modlogEmbed.setDescription(`${description}
 
     //   **TripSit TrustScore: ${trustScore.trustScore}**
@@ -831,7 +642,7 @@ export async function userInfoEmbed(
     if (isInfo(command)) {
       log.debug(F, 'Generating trust score');
       const trustScore = await tripSitTrustScore(targetId);
-      modlogEmbed.setDescription(`${description}
+      modlogEmbed.setDescription(`${description}${threadLink}
 
       ${infoString}
       
@@ -1072,8 +883,6 @@ export async function modResponse(
     timeoutTime = target.communicationDisabledUntilTimestamp;
   }
 
-  // Second row of mod buttons. The primary row caps out at 5.
-  const quickBanRow = new ActionRowBuilder<ButtonBuilder>();
   if (showModButtons) {
     if (isInfo(command) || isReport(command)) {
       actionRow.addComponents(
@@ -1081,11 +890,7 @@ export async function modResponse(
         modButtonWarn(target.id),
         modButtonTimeout(target.id),
         modButtonBan(target.id),
-        modButtonInfo(target.id),
-      );
-      quickBanRow.addComponents(
-        modButtonBanVendor(target.id),
-        modButtonBanBot(target.id),
+        modButtonBanVendorBot(target.id),
       );
     } else if (isTimeout(command) || (timeoutTime && timeoutTime > Date.now())) {
       actionRow.addComponents(
@@ -1134,23 +939,25 @@ export async function modResponse(
 
   log.debug(F, `[modResponse] time: ${Date.now() - startTime}ms`);
 
-  const components = quickBanRow.components.length > 0
-    ? [actionRow, quickBanRow]
-    : [actionRow];
+  const components: ActionRowBuilder<MessageActionRowComponentBuilder>[] = [actionRow];
 
   if (showModButtons && !actorIsMod && isReport(command)) {
-    const actionRowTwo = new ActionRowBuilder<ButtonBuilder>();
-    actionRowTwo.addComponents(modButtonAcknowledgeReport(target.id, actor.id));
-    return {
-      embeds: [modlogEmbed],
-      components: [...components, actionRowTwo],
-    };
+    components.push(new ActionRowBuilder<ButtonBuilder>()
+      .addComponents(modButtonAcknowledgeReport(target.id, actor.id)));
+  }
+
+  if (showModButtons) {
+    components.push(...modHistoryRows(target.id, await modActionCounts(targetData.id)));
   }
 
   return {
     embeds: [modlogEmbed],
     components,
   };
+}
+
+function embedHasMessageField(embed: EmbedBuilder): boolean {
+  return (embed.data.fields ?? []).some(field => field.name === 'Message');
 }
 
 export async function linkThread(
@@ -1251,14 +1058,15 @@ export async function messageModThread(
   log.debug(F, '[messageModThread] generating user info');
   const modlogEmbed = await userInfoEmbed(actor, target, targetData, command, true);
 
+  let messageField: APIEmbedField | undefined;
   try {
     const modEmbedObj = (interaction as ButtonInteraction).message.embeds[0].toJSON();
-    const messageField = (modEmbedObj.fields as APIEmbedField[]).find(field => field.name === 'Message');
-    if (messageField) {
-      modlogEmbed.addFields(messageField);
-    }
+    messageField = (modEmbedObj.fields as APIEmbedField[]).find(field => field.name === 'Message');
   } catch (err) {
     // log.debug(F, `No message field found: ${err}`);
+  }
+  if (messageField) {
+    modlogEmbed.addFields(messageField);
   }
 
   log.debug(F, 'Sending message to mod log');
@@ -1350,9 +1158,15 @@ export async function messageModThread(
       **Note sent to user:** ${(description !== '' && description !== null) ? description : noMessageSent}${deliveryNote}
       ${command === 'NOTE' && !newModThread ? '' : roleModerator}
       `;
+      const threadResponse = await modResponse(interaction, command, true, appealData, actor, typeof target === 'string' ? null : target);
+      // Without the Message field the thread's Warn/Mute/Ban modals open empty.
+      const threadEmbed = threadResponse.embeds?.[0] as EmbedBuilder | undefined;
+      if (messageField && threadEmbed && !embedHasMessageField(threadEmbed)) {
+        threadEmbed.addFields(messageField);
+      }
       await modThread.send({
         content: modThreadMessage,
-        ...await modResponse(interaction, command, true, appealData, actor, typeof target === 'string' ? null : target),
+        ...threadResponse,
       });
     } else {
       const modResponseData = await modResponse(interaction, command, true, appealData);
@@ -1633,6 +1447,25 @@ export async function refusalButton(
   }
 }
 
+function buttonRowsOf(message: Message): APIActionRowComponent<APIButtonComponentWithCustomId>[] {
+  return message.components.map(row => row.toJSON()) as APIActionRowComponent<APIButtonComponentWithCustomId>[];
+}
+
+function isAcknowledgeRow(row: APIActionRowComponent<APIButtonComponentWithCustomId>): boolean {
+  return row.components.some(component => component.custom_id?.includes('~ACKN_REPORT~'));
+}
+
+function hasAcknowledgeButton(message: Message): boolean {
+  return buttonRowsOf(message).some(isAcknowledgeRow);
+}
+
+async function removeAcknowledgeRow(message: Message): Promise<void> {
+  const rows = buttonRowsOf(message).filter(row => !isAcknowledgeRow(row));
+  await message.edit({ components: rows }).catch(err => {
+    log.debug(F, `[removeAcknowledgeRow] could not edit message: ${err}`);
+  });
+}
+
 export async function acknowledgeReportButton(
   buttonInt: ButtonInteraction,
 ) {
@@ -1701,6 +1534,7 @@ export async function acknowledgeReportButton(
           .setColor(Colors.DarkOrange)
           .setDescription('The original reporter of this user has left the server.')],
       });
+      await removeAcknowledgeRow(buttonInt.message);
       log.info(F, 'Could not determine the reporter user.');
       return;
     }
@@ -1715,6 +1549,7 @@ export async function acknowledgeReportButton(
         .setColor(Colors.DarkOrange)
         .setDescription('The user this mod thread is for has deleted their Discord account.')],
     });
+    await removeAcknowledgeRow(buttonInt.message);
     return;
   }
 
@@ -1740,7 +1575,7 @@ export async function acknowledgeReportButton(
     await reporterUser.send(stripIndents`
       Thank you for your report. Users that break our server rules disrupt the server for everyone, and your reports help us identify them.
 
-      While we can't provide specific details about the specific actions taken, your recent report has been acknowledged and action taken. Your reports make TripSit a friendlier place for everyone.
+      While we can't provide specific details about the specific actions taken, your recent report has been acknowledged. Your reports make TripSit a friendlier place for everyone.
 
       If you come across more bad behavior, we hope you'll continue to assist the Tripsit community by reporting it to us.
 
@@ -1759,6 +1594,8 @@ export async function acknowledgeReportButton(
     await targetChan.send({
       embeds: [successEmbed],
     });
+
+    await removeAcknowledgeRow(buttonInt.message);
 
     const guildData = await db.discord_guilds.upsert({
       where: {
@@ -2408,6 +2245,14 @@ export async function modModal(
 
   if (isReportAcknowledgement(command)) {
     await interaction.deferReply({ flags: MessageFlags.Ephemeral });
+    if (!hasAcknowledgeButton(interaction.message)) {
+      await interaction.editReply({
+        embeds: [embedTemplate()
+          .setColor(Colors.DarkOrange)
+          .setDescription('This report has already been acknowledged.')],
+      });
+      return;
+    }
     await acknowledgeReportButton(interaction);
     await interaction.editReply({
       embeds: [embedTemplate()
@@ -2513,10 +2358,9 @@ export async function modModal(
     // log.error(F, `Error: ${err}`);
   }
 
-  // Quick vendor/bot ban shortcut: prefill the reason + a 1-day message purge and leave the
-  // user-facing message blank. The 'Vendor'/'Bot' reason triggers isVendorBotBan (no DM).
-  if (isFullBan(command) && (variant === 'vendor' || variant === 'bot')) {
-    modalInternal = variant === 'vendor' ? 'Vendor' : 'Suspected bot';
+  // 'vendor'/'bot' are legacy variants, still live on already-posted embeds.
+  if (isFullBan(command) && ['vendorbot', 'vendor', 'bot'].includes(variant)) {
+    modalInternal = 'Suspected vendor / bot';
     modalDescription = '';
     modalDays = '1 day';
   }

--- a/src/discord/utils/trust.ts
+++ b/src/discord/utils/trust.ts
@@ -21,9 +21,9 @@ import {
   modButtonNote,
   modButtonTimeout,
   modButtonWarn,
-  tripSitTrustScore,
   userInfoEmbed,
 } from './modUtils';
+import { tripSitTrustScore } from './trustScore';
 // import { checkGuildPermissions } from './checkPermissions';
 import { topic } from '../../global/commands/g.topic';
 import { giveMilestone } from '../../global/utils/experience';

--- a/src/discord/utils/trustScore.ts
+++ b/src/discord/utils/trustScore.ts
@@ -1,0 +1,203 @@
+/* eslint-disable max-len */
+import { stripIndents } from 'common-tags';
+import {
+  DiscordAPIError,
+  Guild,
+  GuildBan,
+  PermissionResolvable,
+} from 'discord.js';
+import { checkGuildPermissions } from './checkPermissions';
+
+// Separate file: modHistory needs this and modUtils imports modHistory.
+export default tripSitTrustScore;
+
+export async function tripSitTrustScore(
+  targetId: string,
+): Promise<{
+    trustScore: number;
+    tsReasoning: string;
+  }> {
+  // const startTime = Date.now();
+  let trustScore = 0;
+  let tsReasoning = '';
+  const targetPromise = discordClient.users.fetch(targetId);
+  const guildsPromise = discordClient.guilds.fetch();
+
+  const target = await targetPromise; // Await here since target is needed for the calculations below
+  // Calculate how like it is that this user is a trust.
+  // This is based off of factors like, how old is their account, do they have a profile picture, etc.
+  const diff = Math.abs(Date.now() - Date.parse(target.createdAt.toString()));
+  const years = Math.floor(diff / (1000 * 60 * 60 * 24 * 365));
+  const months = Math.floor(diff / (1000 * 60 * 60 * 24 * 30));
+  const weeks = Math.floor(diff / (1000 * 60 * 60 * 24 * 7));
+  const days = Math.floor(diff / (1000 * 60 * 60 * 24));
+  const hours = Math.floor((diff % (1000 * 60 * 60 * 24)) / (1000 * 60 * 60));
+  const minutes = Math.floor((diff % (1000 * 60 * 60)) / (1000 * 60));
+  const seconds = Math.floor((diff % (1000 * 60)) / 1000);
+  if (years > 0) {
+    trustScore += 6;
+    tsReasoning += '+6 | Account was created at least a year ago\n';
+  } else if (years === 0 && months > 0) {
+    trustScore += 5;
+    tsReasoning += '+5 | Account was created months ago\n';
+  } else if (months === 0 && weeks > 0) {
+    trustScore += 4;
+    tsReasoning += '+4 | Account was created weeks ago\n';
+  } else if (weeks === 0 && days > 0) {
+    trustScore += 3;
+    tsReasoning += '+3 | Account was created days ago\n';
+  } else if (days === 0 && hours > 0) {
+    trustScore += 2;
+    tsReasoning += '+2 | Account was created hours ago\n';
+  } else if (hours === 0 && minutes > 0) {
+    trustScore += 1;
+    tsReasoning += '+1 | Account was created minutes ago\n';
+  } else if (minutes === 0 && seconds > 0) {
+    trustScore += 0;
+    tsReasoning += '+0 | Account was created seconds ago\n';
+  }
+
+  if (target.avatarURL()) {
+    trustScore += 1;
+    tsReasoning += '+1 | Account has a profile picture\n';
+  } else {
+    trustScore += 0;
+    tsReasoning += '+0 | Account does not have a profile picture\n';
+  }
+
+  // if (target.bannerURL() !== null) {
+  //   trustScore += 1;
+  //   tsReasoning += '+1 | Account has a banner\n';
+  // } else {
+  //   trustScore += 0;
+  //   tsReasoning += '+0 | Account does not have a banner\n';
+  // }
+
+  // Check how many guilds the member is in
+  // await discordClient.guilds.fetch();
+  // const targetInGuilds = await Promise.all(discordClient.guilds.cache.map(async guild => {
+  //   try {
+  //     await guild.members.fetch(target.id);
+  //     // log.debug(F, `User is in guild: ${guild.name}`);
+  //     return guild;
+  //   } catch (err: unknown) {
+  //     return null;
+  //   }
+  // }));
+
+  const [, targetInGuilds] = await Promise.all([
+    guildsPromise, // Await the fetched guilds
+    Promise.all(discordClient.guilds.cache.map(async guild => {
+      if (guild.members.cache.get(target.id)) {
+        return guild;
+      }
+      return null;
+    })),
+  ]);
+  const mutualGuilds = targetInGuilds.filter(item => item);
+
+  if (mutualGuilds.length > 0) {
+    trustScore += mutualGuilds.length;
+    tsReasoning += `+${mutualGuilds.length} | I currently share ${mutualGuilds.length} guilds with them\n`;
+  } else {
+    trustScore += 0;
+    tsReasoning += '+0 | Account is only in this guild, that i can tell\n';
+  }
+
+  await discordClient.guilds.fetch();
+  // const noPermissionGuilds = [] as Guild[];
+  const notFoundGuilds = [] as Guild[];
+  const errorGuilds = [] as Guild[];
+  // const bannedTest = await Promise.all(discordClient.guilds.cache.map(async guild => {
+  //   // log.debug(F, `Checking guild: ${guild.name}`);
+  //   const guildPerms = await checkGuildPermissions(guild, [
+  //     'BanMembers' as PermissionResolvable,
+  //   ]);
+
+  //   if (!guildPerms) {
+  //     // log.debug(F, `No permission to check guild: ${guild.name}`);
+  //     noPermissionGuilds.push(guild);
+  //     return null;
+  //   }
+
+  //   try {
+  //     return await guild.bans.fetch(target.id);
+  //     // log.debug(F, `User is banned in guild: ${guild.name}`);
+  //     // return guild.name;
+  //   } catch (err: unknown) {
+  //     if ((err as DiscordAPIError).code === 10026) {
+  //       // log.debug(F, `User is not banned in guild: ${guild.name}`);
+  //       notFoundGuilds.push(guild);
+  //       return null;
+  //     }
+  //     // log.debug(F, `Error checking guild: ${guild.name}`);
+  //     errorGuilds.push(guild);
+  //     return null;
+  //   }
+  // }));
+
+  // Separate promises for checking permissions and bans
+  const permissionsPromises = discordClient.guilds.cache.map(guild => checkGuildPermissions(guild, ['BanMembers' as PermissionResolvable]));
+  const bansPromises = discordClient.guilds.cache.map(async guild => {
+    try {
+      return guild.bans.cache.get(target.id);
+    } catch (err: unknown) {
+      if ((err as DiscordAPIError).code === 10026) {
+        notFoundGuilds.push(guild);
+        return null;
+      }
+      errorGuilds.push(guild);
+      return null;
+    }
+  });
+
+  const [permissionsResults, bannedTest] = await Promise.all([
+    Promise.all(permissionsPromises),
+    Promise.all(bansPromises),
+  ]);
+
+  // count how many 'banned' appear in the array
+  const bannedGuilds = bannedTest.filter(item => item) as GuildBan[];
+  // log.debug(F, `Banned Guilds: ${bannedGuilds.join(', ')}`);
+
+  // log.debug(F, `permissionsResults: ${permissionsResults}`);
+  // log.debug(F, `bannedTest: ${bannedTest}`);
+  const noPermissionGuilds = permissionsResults.filter(item => !item.hasPermission);
+
+  // count how many i didn't have permission to check
+  // log.debug(F, `No Permission Guilds: ${noPermissionGuilds.map(guild => guild.name).join(', ')}`);
+  // log.debug(F, `Not Found Guilds: ${notFoundGuilds.map(guild => guild.name).join(', ')}`);
+  // log.debug(F, `Error Guilds: ${errorGuilds.map(guild => guild.name).join(', ')}`);
+  const checkedGuildNumber = bannedTest.length - noPermissionGuilds.length;
+
+  if (bannedGuilds.length === 0) {
+    trustScore += 0;
+    tsReasoning += stripIndents`+0 | Not banned in ${checkedGuildNumber} other guilds that I can see.`;
+  } else {
+    trustScore -= (bannedGuilds.length * 5);
+    // eslint-disable-next-line max-len
+
+    const tsBanReasons = (await Promise.all(bannedGuilds.map(async banData => {
+      if (banData.partial) {
+        await banData.fetch();
+      }
+
+      let reasonStr = ': No reason found.';
+      if (banData.reason) {
+        reasonStr = `: ${banData.reason}`;
+      }
+
+      return `${banData.guild.name}${reasonStr}`;
+    }))).join('\n');
+
+    tsReasoning += stripIndents`-${(bannedGuilds.length * 5)} | Banned in least ${bannedGuilds.length} of the ${checkedGuildNumber} guilds I can check.
+    ${tsBanReasons}
+    `;
+  }
+
+  // log.debug(F, `[trust score] time: ${Date.now() - startTime}ms`);
+  return {
+    trustScore,
+    tsReasoning,
+  };
+}


### PR DESCRIPTION
## Summary

- Removed the Info button completely - since no one really uses it, and it was bugging out due to truncation.

- Add a drop-down list below the report user embed where a mod can view user history (previously provided by info above), warn history, report history, note history, ban history and so forth. Each mod action has its own page and mods can now easily flip between pages to see thread history.

- Fixed a bug that would not prepopulate the mod action modal when noting, warning, muting or banning from a user-reported message.

- Added a quick link to go to a user's mod thread for easy access

- Merged the Vendor / Bot buttons to save space

- Hide / disable Acknowledge on a user report once a mod has acknowledged it

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [x] Refactor / chore
- [x] Other (describe above)

## Checklist

- [x] Branch is up to date with `uat` (this PR targets `uat`, not `main`)
- [x] Lint passes for changed files (`npx eslint --ext .ts,.js path/to/file.ts`)
- [x] Type-check passes (`npx tsc --noEmit --pretty false`)
- [x] Relevant tests pass (`npm run tripbot:test -- --runInBand`)
- [x] No secrets, `.env` values, database dumps, or user data included
- [ ] Discord command definitions changed? Note that deployment must be requested separately (not done in this PR)

## Test plan

Everything was tested in the dev server with screenshots to show. Tested as both a mod and normal user to ensure commands are still locked down properly.

The new report embed with link, merged buttons and drop-down list:

<img width="761" height="350" alt="Screenshot 2026-08-31 132609" src="https://github.com/user-attachments/assets/7325a8c2-cb9c-477b-98ac-824750a33144" />

Drop-down list content is context sensitive and won't show options that don't apply to the user:

<img width="746" height="371" alt="Screenshot 2026-08-31 133318" src="https://github.com/user-attachments/assets/3510d549-8223-46f4-a975-0885d557bec2" />

New Profile and Trust Score view to replace the old Info button:

<img width="884" height="758" alt="Screenshot 2026-08-31 135903" src="https://github.com/user-attachments/assets/88313cf5-3d6e-4562-833a-b261dfac2a02" />
