### PR TITLE
Remove redundant VIP 0 role grant in experience.ts

### DIFF
--- a/src/global/utils/experience.ts
+++ b/src/global/utils/experience.ts
@@ -296,11 +296,6 @@ export async function experience(
     await db.user_experience.create({
       data: newUser,
     });
-    if (type === 'TEXT') {
-      // Give the user the VIP 0 role the first time they talk
-      const role = await channel.guild?.roles.fetch(env.ROLE_VIP_0) as Role;
-      await member.roles.add(role);
-    }
     return;
   }
 


### PR DESCRIPTION
## Summary
- Salvaged from the stale `removing-verified-role` branch (never had a PR, 251 commits behind main).
- Removes the code in `experience()` that grants the VIP 0 role the first time a user talks — this is redundant since `guildMemberAdd` already calls `giveMilestone(member)` on join, which assigns `ROLE_VIP_0` for level-0 users via the same role table.

## Test plan
- [ ] Confirm new members still receive the VIP 0 role on join (via `giveMilestone`)
- [ ] Confirm no role-assignment errors on a user's first text message

🤖 Generated with [Claude Code](https://claude.com/claude-code)