### PR TITLE
Skip TripBot PR notification when API secrets are unavailable

### DIFF
--- a/.github/workflows/PullRequestOpenAll.yml
+++ b/.github/workflows/PullRequestOpenAll.yml
@@ -214,6 +214,11 @@ jobs:
           TRIPBOT_API_URL: ${{ secrets.TRIPBOT_API_URL }}
           TRIPBOT_API_TOKEN: ${{ secrets.TRIPBOT_API_TOKEN }}
         run: |
+          if [ -z "$TRIPBOT_API_URL" ]; then
+            echo "::notice::Skipping TripBot notification (no API URL — likely a Dependabot-triggered run without secret access)"
+            exit 0
+          fi
+
           echo "Payload sent to TripBot:"
           cat pr-notify-payload.json
           echo ""


### PR DESCRIPTION
## Summary
- Found while looking into why [PR #1236](https://github.com/TripSit/TripBot/pull/1236) (a Dependabot security-fix bump of `fast-uri`/`qs`) showed a failing check despite Lint/Build/Test all passing.
- Root cause: GitHub withholds repository secrets from workflow runs triggered by Dependabot (security measure, so a compromised dependency can't exfiltrate secrets via a malicious PR). The "Notify Discord of PR" job's `curl` call hits an empty `$TRIPBOT_API_URL`, fails with `curl: (3) URL rejected: No host part in the URL`, and the check goes red.
- This isn't fixable by granting Dependabot the secret — the fix is having the step recognize it has no secret to work with and skip gracefully instead of failing.

## Change
- [PullRequestOpenAll.yml](.github/workflows/PullRequestOpenAll.yml): if `TRIPBOT_API_URL` is empty, log a notice and exit 0 instead of attempting the request.

## Test plan
- [ ] Confirm a future Dependabot PR shows the notify step passing (skipped) instead of failing
- [ ] Confirm the notify step still posts to Discord normally on human/Claude-authored PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)